### PR TITLE
update deployhq API helper call

### DIFF
--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -122,7 +122,8 @@ class API_Helper {
 			'http' => array(
 				'header'  => $headers,
 				'method'  => $method,
-				'content' => $data
+				'content' => $data,
+				'timeout' => 60
 			)
 		);
 


### PR DESCRIPTION
Added a 60 sec timeout value to `@file_get_contents()` which seems to be helping me when creating deployhq configs was otherwise failing. Might need further tuning, I picked 60 seconds by random after reading comments on https://www.php.net/manual/en/function.file-get-contents.php

cc: @pippercameron