### PR TITLE
Allow branch specification when creating development sites.

### DIFF
--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -121,7 +121,8 @@ class API_Helper {
 				'header'  => $headers,
 				'method'  => $method,
 				'content' => $data,
-				'timeout' => 60
+				'timeout' => 60,
+				'ignore_errors' => true,
 			)
 		);
 


### PR DESCRIPTION
Some minor refactoring to the development site creation flow.
Removed `-temporary-clone` from the naming scheme (there is a 50 char
limit in Pressable site names and this + a timestamp makes it easy to
hit that limit).