### PR TITLE
Branch protection rules command!

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -16,5 +16,6 @@ $application = new Application();
 $application->add( new Team51\Command\Create_Production_Site() );
 $application->add( new Team51\Command\Create_Development_Site() );
 $application->add( new Team51\Command\Create_Repository() );
+$application->add( new Team51\Command\Add_Branch_Protection_Rules() );
 
 $application->run();

--- a/src/commands/add-branch-protection-rules.php
+++ b/src/commands/add-branch-protection-rules.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Add_Branch_Protection_Rules extends Command {
+    protected static $defaultName = 'add-branch-protection-rules';
+
+    protected function configure() {
+        $this
+        ->setDescription( "Adds predefined branch protection rules to a given GitHub repository." )
+        ->setHelp( "Allows adding branch protection rules to a GitHub repository.." )
+        ->addArgument( 'repo-slug', InputArgument::REQUIRED, "Repository name in slug form (e.g. client-name)?" );
+    }
+
+    protected function execute( InputInterface $input, OutputInterface $output ) {
+        $api_helper = new API_Helper;
+
+	$slug = $input->getArgument( 'repo-slug' );
+
+	// TODO: Allow these rules to be managed via the config.json file.
+
+        $branch_protection_rules = array (
+            'required_status_checks' => array (
+                'strict' => true,
+                'contexts' => array (
+                    'Travis CI - Branch',
+                    'Travis CI - Pull Request',
+                ),
+            ),
+            'enforce_admins' => null,
+            'required_pull_request_reviews' => null,
+            'restrictions' => null,
+        );
+
+        $output->writeln( "<comment>Adding branch protection rules to $slug.</comment>" );
+        $branch_protection_rules = $api_helper->call_github_api( "repos/" . GITHUB_API_OWNER . "/$slug/branches/master/protection", $branch_protection_rules, 'PUT' );
+
+	if ( ! empty( $branch_protection_rules->required_status_checks->contexts ) ) {
+		$output->writeln( "<info>Done. Added branch protection rules to $slug.</info>" );
+	} else {
+		$output->writeln( "<info>Failed to add branch protection rules to $slug.</info>" );
+	}
+    }
+}


### PR DESCRIPTION
Branch protection rules can now be added to an existing GitHub
repository with `team51
add-branch-protection-rules <repo-slug>`.