### PR TITLE
Pass working directory to composer.

### DIFF
--- a/team51-cli.php
+++ b/team51-cli.php
@@ -4,7 +4,7 @@
 echo "Checking for updates.." . PHP_EOL;
 exec( sprintf( "git -C %s %s",  __DIR__, 'pull' ) );
 // TODO: Only run this when there are updates.
-exec( "composer dump-autoload -o" );
+exec( sprintf( "composer dump-autoload -o --working-dir %s", __DIR__ ) );
 echo PHP_EOL;
 
 require __DIR__ . '/load-application.php';


### PR DESCRIPTION
Allows it to run correctly when the team51 command is called outside of
the root dir.