### PR TITLE
Add Front commands

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -18,5 +18,7 @@ $application->add( new Team51\Command\Create_Development_Site() );
 $application->add( new Team51\Command\Create_Repository() );
 $application->add( new Team51\Command\Add_Branch_Protection_Rules() );
 $application->add( new Team51\Command\Jetpack_Enable_SSO() );
+$application->add( new Team51\Command\Front_Create_Export() );
+$application->add( new Team51\Command\Front_List_Exports() );
 
 $application->run();

--- a/src/commands/front-create-export.php
+++ b/src/commands/front-create-export.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Front_Create_Export extends Command {
+    protected static $defaultName = 'front-create-export';
+
+    protected function configure() {
+        $this
+        ->setDescription( 'Creates an export request in Front for all messages or messages within a specific timeframe.' )
+		->setHelp( 'This command creates an export request in Front. Exports take some time to process, use the `team51 front-list-exports` command to see all available exports and their statuses.' )
+		->addArgument( 'start-date', InputArgument::OPTIONAL, 'The Start Date in YYYY-MM-DD format' )
+		->addArgument( 'end-date', InputArgument::OPTIONAL, 'The End Date in YYYY-MM-DD format' );
+    }
+
+    protected function execute( InputInterface $input, OutputInterface $output ) {
+		$start_date = $input->getArgument( 'start-date' );
+
+		// Start date.
+		if ( ! empty( $start_date ) ) {
+			$start_date = strtotime( $start_date );
+		} else {
+			$start_date = strtotime( '2015-01-01' ); // A date before we started using Front.
+		}
+
+		if ( empty( $start_date ) ) {
+			$output->writeln( '<error>Invalid Start Date.</error>' );
+			exit;
+		}
+
+		// End date.
+		$end_date = $input->getArgument( 'end-date' );
+
+		if ( ! empty( $end_date ) ) {
+			$end_date = strtotime( $end_date );
+		} else {
+			$end_date = time();
+		}
+
+		if ( empty( $end_date ) ) {
+			$output->writeln( '<error>Invalid End Date.</error>' );
+			exit;
+		}
+
+		if ( $start_date >= $end_date ) {
+			$output->writeln( '<error>The End Date must come after the Start Date.</error>' );
+			exit;
+		}
+
+		$api_helper = new API_Helper;
+
+		$data = array(
+			'start' => $start_date,
+			'end'   => $end_date,
+		);
+
+		$result = $api_helper->call_front_api( 'exports', $data, 'POST' );
+
+		if ( empty( $result->id ) || empty( $result->status ) ) {
+			$output->writeln( '<error>Oh no, something went wrong!</error>' );
+		}
+
+		$output->writeln( 'Asking Front to generate a new export...' );
+		$output->writeln( sprintf( '<info>A new export request was created with the ID %s. Current status is %s.</info>', $result->id, ucfirst( $result->status ) ) );
+		$output->writeln( '<comment>Use the `team51 front-list-exports` command to check on the export status and get a download link.</comment>' );
+    }
+}

--- a/src/commands/front-create-export.php
+++ b/src/commands/front-create-export.php
@@ -60,13 +60,14 @@ class Front_Create_Export extends Command {
 			'end'   => $end_date,
 		);
 
+		$output->writeln( 'Asking Front to generate a new export...' );
+
 		$result = $api_helper->call_front_api( 'exports', $data, 'POST' );
 
 		if ( empty( $result->id ) || empty( $result->status ) ) {
 			$output->writeln( '<error>Oh no, something went wrong!</error>' );
 		}
 
-		$output->writeln( 'Asking Front to generate a new export...' );
 		$output->writeln( sprintf( '<info>A new export request was created with the ID %s. Current status is %s.</info>', $result->id, ucfirst( $result->status ) ) );
 		$output->writeln( '<comment>Use the `team51 front-list-exports` command to check on the export status and get a download link.</comment>' );
     }

--- a/src/commands/front-list-exports.php
+++ b/src/commands/front-list-exports.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+class Front_List_Exports extends Command {
+	protected static $defaultName = 'front-list-exports';
+
+	protected function configure() {
+		$this
+		->setDescription( 'Lists the most recent Front exports and their respective download links.' )
+		->setHelp( 'Use this command to get the most recent exports from Front. Use Command + Click on the filename to download the export.' );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$api_helper = new API_Helper;
+		$exports    = $api_helper->call_front_api( 'exports' );
+
+		if ( empty( $exports->_results ) ) {
+			$output->writeln( '<error>Oh no, something went wrong!</error>' );
+			$output->writeln( '<comment>Are you sure an export request has been initiated?</comment>' );
+		}
+
+		$table_data = array();
+
+		foreach ( $exports->_results as $export ) {
+			$url = '';
+
+			if ( ! empty( $export->url ) ) {
+				preg_match( '/export-messages-wordpress_concierge-(.*)/', $export->url, $matches );
+				$url = sprintf( '<href=%s>%s</>', $export->url, $matches[1] );
+			}
+
+			$table_data[] = array(
+				$export->id,
+				date( 'Y-m-d h:i:s A', $export->created_at ),
+				ucfirst( $export->status ),
+				$url
+			);
+		}
+
+		$table = new Table( $output );
+
+		$table
+			->setHeaders( array( 'ID', 'Date', 'Status', 'Download' ) )
+			->setRows( $table_data );
+
+		$table->render();
+	}
+}

--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -198,4 +198,33 @@ class API_Helper {
 
 		return json_decode( $result );
 	}
+
+	public function call_front_api( $query, $data = array(), $method = 'GET' ) {
+		$api_request_url = FRONT_API_ENDPOINT . $query;
+
+		$headers = array(
+			'Accept: application/json',
+			'Content-Type: application/json',
+			'Authorization: Bearer '. FRONT_API_TOKEN,
+			'User-Agent: PHP',
+		);
+
+		$options = array(
+			'http' => array(
+				'header'        => $headers,
+				'ignore_errors' => true,
+			)
+		);
+
+		if ( ! empty( $data ) && in_array( $method, array( 'POST', 'PUT' ) ) ) {
+			$data = json_encode( $data );
+			$options['http']['content'] = $data;
+			$options['http']['method']  = $method;
+		}
+
+		$context = stream_context_create( $options );
+		$result = @file_get_contents( $api_request_url, false, $context );
+
+		return json_decode( $result );
+	}
 }

--- a/src/helpers/config-loader.php
+++ b/src/helpers/config-loader.php
@@ -127,6 +127,20 @@ if( ! empty( $config->WPCOM_API_ACCOUNT_TOKEN ) ) {
 	die();
 }
 
+if( ! empty( $config->FRONT_API_ENDPOINT ) ) {
+	define( 'FRONT_API_ENDPOINT', $config->FRONT_API_ENDPOINT );
+} else {
+	echo "Warning: FRONT_API_ENDPOINT could not be set. Aborting!\n";
+	die();
+}
+
+if( ! empty( $config->FRONT_API_TOKEN ) ) {
+	define( 'FRONT_API_TOKEN', $config->FRONT_API_TOKEN );
+} else {
+	echo "Warning: FRONT_API_TOKEN could not be set. Aborting!\n";
+	die();
+}
+
 if( ! empty( $config->SLACK_WEBHOOK_URL ) ) {
 	define( 'SLACK_WEBHOOK_URL', $config->SLACK_WEBHOOK_URL );
 } else {


### PR DESCRIPTION
This PR introduces two new commands: `front-create-export` and `front-list-exports`.

The `front-create-export` creates a request with Front for an export. Exports take some time to complete so this command will only confirm that a request has been initiated. Custom timeframes are also supported with the `start-date` and `end-date` arguments.

<img width="696" alt="front-create-export" src="https://user-images.githubusercontent.com/1177726/85422958-0e598800-b56e-11ea-88ad-a9345654a462.png">

The `front-list-exports` lists the most recent exports and their statuses in a table format. To download the export Command + Click on the filename.

<img width="547" alt="front-list-exports" src="https://user-images.githubusercontent.com/1177726/85422573-ac008780-b56d-11ea-8911-1b508514be2c.png">

The `config.json` file has been updated to include the Front token.

