### PR TITLE
escape script path

### DIFF
--- a/install-osx
+++ b/install-osx
@@ -3,4 +3,4 @@ composer install
 composer dump-autoload -o
 sudo mkdir -p /usr/local/bin
 script_path=$(pwd)
-sudo ln -sf $script_path/team51-cli.php /usr/local/bin/team51
+sudo ln -sf "$script_path"/team51-cli.php /usr/local/bin/team51


### PR DESCRIPTION
## Synopsis

Fixes issue with spaces in script path by wrapping the variable output in double quotes, as per: https://yuji.wordpress.com/2011/12/28/bash-escape-spaces-in-results-of-pwd-command/

## Issue

Fixes #26 

## To Test 
Put script in a directory with a space in the folder name.
Run `./install-osx`
Script completes without error.