### PR TITLE
Updating phpseclib version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "symfony/console": "^4.3",
         "symfony/filesystem": "^4.3",
         "symfony/process": "^4.3",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib": "^3.0.7"
     },
     "autoload": {
 	"classmap": ["src/"]


### PR DESCRIPTION
Make sure we use at least 3.0.7, which patched RSA signature issue.