### PR TITLE
create-repository adds 2 files to allow plugins to skip code checks

### DIFF
--- a/scaffold/templates/EXAMPLE-README.md
+++ b/scaffold/templates/EXAMPLE-README.md
@@ -8,6 +8,7 @@ This repo is for EXAMPLE_REPO_NAME, powered by WordPress.
 - The main `themes`, `plugins`, and `mu-plugins` directories are ignored
 - Project-relevant themes and plugins are added as exceptions to the `.gitignore` file so they will be tracked
 
+If the PHPCS checks are taking too long because of a plugin/code that we aren't responsible for, feel free to include that plugin folder in the files `.vipgoci_lint_skip_folders` and `.vipgoci_phpcs_skip_folders`. Please use this feature sparingly. We view the checks as a safety mechanism that can save sites from serious errors.
 
 If `mu-plugins` are needed for a project, create a `mu-plugins` directory and include a `mu-autoloader.php` file within that mu-plugins directory (`/mu-plugins/mu-autoloader.php`). In that `mu-autoloader.php` file, add the following contents:
 

--- a/scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders
+++ b/scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders
@@ -1,0 +1,2 @@
+mu-plugins/my-third-party-plugin
+plugins/my-third-party-plugin

--- a/scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders
+++ b/scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders
@@ -1,0 +1,2 @@
+mu-plugins/my-third-party-plugin
+plugins/my-third-party-plugin

--- a/src/commands/create-repository.php
+++ b/src/commands/create-repository.php
@@ -68,12 +68,12 @@ class Create_Repository extends Command {
 			$output->writeln( "<comment>Creating scaffold/$slug/plugins directory.</comment>" );
 			$filesystem->mkdir( TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins" );
 
-      $output->writeln( "<comment>Creating scaffold/$slug/plugins/plugin-autoupdate-filter directory.</comment>" );
+			$output->writeln( "<comment>Creating scaffold/$slug/plugins/plugin-autoupdate-filter directory.</comment>" );
 			$filesystem->mkdir( TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter" );
-      $output->writeln( "<comment>Copying scaffold/plugin-autoupdate-filter plugin folder to scaffold/$slug/plugins/plugin-autoupdate-filter.</comment>" );
+			$output->writeln( "<comment>Copying scaffold/plugin-autoupdate-filter plugin folder to scaffold/$slug/plugins/plugin-autoupdate-filter.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/plugin-autoupdate-filter/plugin-autoupdate-filter.php', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter/plugin-autoupdate-filter.php" );
-      $filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/plugin-autoupdate-filter/class-plugin-autoupdate-filter.php', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter/class-plugin-autoupdate-filter.php" );
-      $filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/plugin-autoupdate-filter/README.md', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter/README.md" );
+			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/plugin-autoupdate-filter/class-plugin-autoupdate-filter.php', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter/class-plugin-autoupdate-filter.php" );
+			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/plugin-autoupdate-filter/README.md', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/plugins/plugin-autoupdate-filter/README.md" );
 
 			$output->writeln( "<comment>Copying scaffold/templates/gitignore file to scaffold/$slug/.gitignore.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/gitignore', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.gitignore" );
@@ -89,6 +89,12 @@ class Create_Repository extends Command {
 
 			$output->writeln( "<comment>Copying scaffold/templates/EXAMPLE-README.md file to scaffold/$slug/README.md.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/EXAMPLE-README.md', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/README.md" );
+			
+			$output->writeln( "<comment>Copying scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders file to scaffold/$slug/.vipgoci_phpcs_skip_folders.</comment>" );
+			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.vipgoci_phpcs_skip_folders" );
+			
+			$output->writeln( "<comment>Copying scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders file to scaffold/$slug/.vipgoci_lint_skip_folders.</comment>" );
+			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.vipgoci_lint_skip_folders" );
 
 			$readme = file_get_contents( TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/README.md" );
 


### PR DESCRIPTION
[team51-dev-requests/issues/628](https://github.com/a8cteam51/team51-dev-requests/issues/628).

Created 2 reference files to allow some plugins to skip PHPCS and PHP Lint checks.

Files created are `.vipgoci_lint_skip_folders` and `.vipgoci_phpcs_skip_folders`. 

These are just samples and don't actually skip any specific plugin, but work as a guide for the developer.

The affected command is `create-repository`, and when it finalizes executing, it would create a standard repository containing these two files in the root directory. Once created, the files' content look like this:

<img width="492" alt="Screen Shot 2021-09-14 at 13 59 57" src="https://user-images.githubusercontent.com/1821060/133327425-04ce7d34-6846-4fd5-b6b1-3eee2eb46e75.png">


To test it, run `create-repository  --repo-slug [projects-name]` 