### PR TITLE
Store Pressable token in local JSON file to re-use for next call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.json
 vendor/
 .DS_Store
+src/helpers/pressable_token.json

--- a/load-application.php
+++ b/load-application.php
@@ -29,5 +29,6 @@ $application->add( new Team51\Command\Remove_User() );
 $application->add( new Team51\Command\DevQueue_Triage_Digest() );
 $application->add( new Team51\Command\Update_Repository_Secret() );
 $application->add( new Team51\Command\Plugin_List() );
+$application->add( new Team51\Command\Pressable_Generate_Token() );
 
 $application->run();

--- a/src/commands/increase-ulimit
+++ b/src/commands/increase-ulimit
@@ -1,0 +1,2 @@
+#!/bin/bash
+ulimit -n 16000

--- a/src/commands/pressable-generate-token.php
+++ b/src/commands/pressable-generate-token.php
@@ -45,21 +45,15 @@ class Pressable_Generate_Token extends Command {
 			}
 		}
 
-		$output->writeln( '<comment>Generating OAuth token on Pressable.</comment>' );
+		$output->writeln( '<comment>Generating Refresh Token from Pressable.</comment>' );
 
-		$token = $this->api_helper->get_pressable_api_token( $client_id, $client_secret );
+		$tokens = $this->api_helper->get_pressable_api_auth_tokens( $client_id, $client_secret );
 
-		$output->writeln( "<info>\nPressable OAuth Token:\n{$token}\n</info>" );
+		$output->writeln( "<info>\nPressable Refresh Token:\n{$tokens['refresh_token']}\n</info>" );
 
-		$table = new Table( $output );
-		$table->setStyle( 'box-double' );
-		$table->setHeaders( array( 'Key', 'Value' ) );
-		$table->setRows( array(
-			array( 'PRESSABLE_API_APP_CLIENT_ID', $client_id ),
-			array( 'PRESSABLE_API_APP_CLIENT_SECRET', $client_secret ),
-			array( 'PRESSABLE_API_OAUTH_TOKEN', $token ),
-		) );
-		$table->render();
+		$output->writeln( '"PRESSABLE_API_APP_CLIENT_ID":"' . $client_id . '",' );
+		$output->writeln( '"PRESSABLE_API_APP_CLIENT_SECRET":"' . $client_secret . '",' );
+		$output->writeln( '"PRESSABLE_API_REFRESH_TOKEN":"' . $tokens['refresh_token'] . '",' );
 
 		$output->writeln( "<info>\nAll done!<info>" );
 	}

--- a/src/commands/pressable-generate-token.php
+++ b/src/commands/pressable-generate-token.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+class Pressable_Generate_Token extends Command {
+	protected static $defaultName = 'pressable-generate-token';
+	private $api_helper;
+	private $output;
+
+	protected function configure() {
+		$this
+		->setDescription( 'Generates a Pressable token based on Client ID and Client Secret.' )
+		->setHelp( 'This command allows you to generate a Pressable OAuth token for a given API Client ID and Client Secret.' )
+		->addOption( 'client_id', null, InputOption::VALUE_REQUIRED, "The Client ID." )
+		->addOption( 'client_secret', null, InputOption::VALUE_REQUIRED, "The Client Secret." );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$this->api_helper = new API_Helper();
+		$this->output     = $output;
+
+		$client_id = $input->getOption( 'client_id' );
+		$client_secret = $input->getOption( 'client_secret' );
+
+		if ( empty( $client_id ) ) {
+			$client_id = trim( readline( 'Please provide the Pressable Client ID: ' ) );
+			if ( empty( $client_id ) ) {
+				$output->writeln( '<error>Missing Client ID (--client_id=A1B2C3XYZ).</error>' );
+				exit;
+			}
+		}
+
+		if ( empty( $client_secret ) ) {
+			$client_secret = trim( readline( 'Please provide the Pressable Client Secret: ' ) );
+			if ( empty( $client_secret ) ) {
+				$output->writeln( '<error>Missing Client Secret (--client_secret=A1B2C3XYZ).</error>' );
+				exit;
+			}
+		}
+
+		$output->writeln( '<comment>Generating OAuth token on Pressable.</comment>' );
+
+		$token = $this->api_helper->get_pressable_api_token( $client_id, $client_secret );
+
+		$output->writeln( "<info>\nPressable OAuth Token:\n{$token}\n</info>" );
+
+		$table = new Table( $output );
+		$table->setStyle( 'box-double' );
+		$table->setHeaders( array( 'Key', 'Value' ) );
+		$table->setRows( array(
+			array( 'PRESSABLE_API_APP_CLIENT_ID', $client_id ),
+			array( 'PRESSABLE_API_APP_CLIENT_SECRET', $client_secret ),
+			array( 'PRESSABLE_API_OAUTH_TOKEN', $token ),
+		) );
+		$table->render();
+
+		$output->writeln( "<info>\nAll done!<info>" );
+	}
+}

--- a/src/commands/pressable-generate-token.php
+++ b/src/commands/pressable-generate-token.php
@@ -16,8 +16,8 @@ class Pressable_Generate_Token extends Command {
 
 	protected function configure() {
 		$this
-		->setDescription( 'Generates a Pressable token based on Client ID and Client Secret.' )
-		->setHelp( 'This command allows you to generate a Pressable OAuth token for a given API Client ID and Client Secret.' )
+		->setDescription( 'Generates a Pressable token based on Client ID and Client Secret, to be used on config.json' )
+		->setHelp( 'Requires --client_id and --client_secret. This command allows you to generate a Pressable OAuth token for a given API Application Client ID and Client Secret. This allows external collaborators to have access to Pressable functionality using Team51 CLI.' )
 		->addOption( 'client_id', null, InputOption::VALUE_REQUIRED, "The Client ID." )
 		->addOption( 'client_secret', null, InputOption::VALUE_REQUIRED, "The Client Secret." );
 	}
@@ -49,7 +49,7 @@ class Pressable_Generate_Token extends Command {
 
 		$tokens = $this->api_helper->get_pressable_api_auth_tokens( $client_id, $client_secret );
 
-		$output->writeln( "<info>\nPressable Refresh Token:\n{$tokens['refresh_token']}\n</info>" );
+		$output->writeln( "<info>\nProvide the following lines to the external collaborator. These should be placed on their config.json file:\n</info>" );
 
 		$output->writeln( '"PRESSABLE_API_APP_CLIENT_ID":"' . $client_id . '",' );
 		$output->writeln( '"PRESSABLE_API_APP_CLIENT_SECRET":"' . $client_secret . '",' );

--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -5,7 +5,7 @@ namespace Team51\Helper;
 class API_Helper {
 
 	private const PRESABLE_TOKEN_FILE         = __DIR__ . '/pressable_token.json';
-	private const PRESABLE_TOKEN_EXPIRE_AFTER = '-23 hours';
+	private const PRESABLE_TOKEN_EXPIRE_AFTER = '-8 hours';
 
 	public function call_pressable_api( $query, $method, $data ) {
 		$api_request_url = PRESSABLE_API_ENDPOINT . $query;
@@ -343,27 +343,24 @@ class API_Helper {
 	}
 
 	/**
-	 * Retrieves the last stored Pressable refresh token, or PRESSABLE_API_REFRESH_TOKEN by default
-	 * If token is expired, returns false
+	 * Retrieves the last stored Pressable refresh token, 
+	 * or PRESSABLE_API_REFRESH_TOKEN by default
 	 */
 	private function get_local_pressable_refresh_token() {
 		if ( ! file_exists( self::PRESABLE_TOKEN_FILE ) ) {
 			if ( defined( 'PRESSABLE_API_REFRESH_TOKEN' ) ) {
+				echo "Using PRESSABLE_API_REFRESH_TOKEN from config.json file\n";
 				return PRESSABLE_API_REFRESH_TOKEN;
 			} else {
 				// No local token stored in JSON nor config file
+				echo "No PRESSABLE_API_REFRESH_TOKEN found. Please check your config.json file \n";
 				return false;
 			}
 		}
 
 		$data = json_decode( file_get_contents( self::PRESABLE_TOKEN_FILE ) );
-
 		if ( ! $data ) {
-			return false;
-		}
-
-		if( intval( $data->pressable_token_timestamp ) < strtotime( self::PRESABLE_TOKEN_EXPIRE_AFTER ) ) {
-			// Pressable token expired
+			echo "Could not read pressable_token.json file";
 			return false;
 		}
 

--- a/src/helpers/config-loader.php
+++ b/src/helpers/config-loader.php
@@ -107,23 +107,25 @@ if( ! empty( $config->PRESSABLE_API_APP_CLIENT_SECRET ) ) {
 	die();
 }
 
-if( empty( $config->PRESSABLE_ACCOUNT_EMAIL ) && empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
-	echo "Neither PRESSABLE_ACCOUNT_EMAIL or PRESSABLE_OAUTH_TOKEN could be set. Aborting!\n";
+if( empty( $config->PRESSABLE_ACCOUNT_EMAIL ) && empty( $config->PRESSABLE_API_REFRESH_TOKEN ) ) {
+	echo "Neither PRESSABLE_ACCOUNT_EMAIL or PRESSABLE_API_REFRESH_TOKEN could be set. Aborting!\n";
 	die();
 } else {
 	if ( ! empty( $config->PRESSABLE_ACCOUNT_EMAIL ) ) {
 		define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_ACCOUNT_EMAIL );
 	}
-	if ( ! empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
-		define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_OAUTH_TOKEN );
+	if ( ! empty( $config->PRESSABLE_API_REFRESH_TOKEN ) ) {
+		define( 'PRESSABLE_API_REFRESH_TOKEN', $config->PRESSABLE_API_REFRESH_TOKEN );
 	}
 }
 
-if( empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) && empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
-	echo "Neither PRESSABLE_ACCOUNT_PASSWORD or PRESSABLE_OAUTH_TOKEN could be set. Aborting!\n";
+if( empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) && empty( $config->PRESSABLE_API_REFRESH_TOKEN ) ) {
+	echo "Neither PRESSABLE_ACCOUNT_PASSWORD or PRESSABLE_API_REFRESH_TOKEN could be set. Aborting!\n";
 	die();
 } else {
-	define( 'PRESSABLE_ACCOUNT_PASSWORD', $config->PRESSABLE_ACCOUNT_PASSWORD );
+	if ( ! empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) ) {
+		define( 'PRESSABLE_ACCOUNT_PASSWORD', $config->PRESSABLE_ACCOUNT_PASSWORD );
+	}
 }
 
 if( ! empty( $config->WPCOM_API_ENDPOINT ) ) {

--- a/src/helpers/config-loader.php
+++ b/src/helpers/config-loader.php
@@ -107,18 +107,23 @@ if( ! empty( $config->PRESSABLE_API_APP_CLIENT_SECRET ) ) {
 	die();
 }
 
-if( ! empty( $config->PRESSABLE_ACCOUNT_EMAIL ) ) {
-	define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_ACCOUNT_EMAIL );
-} else {
-	echo "PRESSABLE_ACCOUNT_EMAIL could not be set. Aborting!\n";
+if( empty( $config->PRESSABLE_ACCOUNT_EMAIL ) && empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
+	echo "Neither PRESSABLE_ACCOUNT_EMAIL or PRESSABLE_OAUTH_TOKEN could be set. Aborting!\n";
 	die();
+} else {
+	if ( ! empty( $config->PRESSABLE_ACCOUNT_EMAIL ) ) {
+		define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_ACCOUNT_EMAIL );
+	}
+	if ( ! empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
+		define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_OAUTH_TOKEN );
+	}
 }
 
-if( ! empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) ) {
-	define( 'PRESSABLE_ACCOUNT_PASSWORD', $config->PRESSABLE_ACCOUNT_PASSWORD );
-} else {
-	echo "PRESSABLE_ACCOUNT_PASSWORD could not be set. Aborting!\n";
+if( empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) && empty( $config->PRESSABLE_OAUTH_TOKEN ) ) {
+	echo "Neither PRESSABLE_ACCOUNT_PASSWORD or PRESSABLE_OAUTH_TOKEN could be set. Aborting!\n";
 	die();
+} else {
+	define( 'PRESSABLE_ACCOUNT_PASSWORD', $config->PRESSABLE_ACCOUNT_PASSWORD );
 }
 
 if( ! empty( $config->WPCOM_API_ENDPOINT ) ) {


### PR DESCRIPTION
This PR adds a new command `pressable-generate-token` that receives a `client_id` and `client_secret`

The full command to run is:
`team51 pressable-generate-token --client_id=ABC123 --client_secret=ABC123`, where Client ID and Client Secret are values previously created from the Pressable API Applications

The command will return not only the token, but the lines that the user will need to place on their `config.json`

Test that the token works can be a little tricky, just keep in mind the following:
 - Replace `config.json` with the new token and client/secret values. These replace the email and password
 - If present, remove any file called `pressable_tokens.json` from `src/helpers`, otherwise the CLI will use your old token