### PR TITLE
Added condition for --no-interaction and updated language

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.0",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
+                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
                 "shasum": ""
             },
             "require": {
@@ -85,7 +85,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.0"
+                "source": "https://github.com/amphp/amp/tree/v2.6.1"
             },
             "funding": [
                 {
@@ -93,7 +93,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-16T20:06:06+00:00"
+            "time": "2021-09-23T18:43:08+00:00"
         },
         {
             "name": "amphp/byte-stream",

--- a/install-osx
+++ b/install-osx
@@ -1,4 +1,5 @@
 #!/bin/bash
+ulimit -n 4096
 composer install
 composer dump-autoload -o
 sudo mkdir -p /usr/local/bin

--- a/src/commands/remove-user.php
+++ b/src/commands/remove-user.php
@@ -107,9 +107,11 @@ class Remove_User extends Command {
 		}
 
 		// Remove?
-		$confirm_remove = trim( readline( 'Are you sure you want to remove this user from WordPress.com and Pressable? (y/n) ' ) );
-		if ( 'y' !== $confirm_remove ) {
-			exit;
+		if ( ! $input->getOption( 'no-interaction' ) ) {
+			$confirm_remove = trim( readline( 'Are you sure you want to remove this user from WordPress.com and Pressable? (y/n) ' ) );
+			if ( 'y' !== $confirm_remove ) {
+				exit;
+			}
 		}
 
 		// Remove from Pressable
@@ -139,7 +141,7 @@ class Remove_User extends Command {
 	private function get_wpcom_users( $email ) {
 		$wp_bearer_token = WPCOM_API_ACCOUNT_TOKEN;
 
-		$this->output->writeln( '<comment>Fetching list of wpcom sites...</comment>' );
+		$this->output->writeln( '<comment>Fetching list of WordPress.com & Jetpack sites...</comment>' );
 
 		$result = $this->api_helper->call_wpcom_api( 'rest/v1.1/me/sites/?fields=ID,URL', array() );
 
@@ -148,7 +150,7 @@ class Remove_User extends Command {
 			exit;
 		}
 
-		$this->output->writeln( "<comment>Searching for '$email' across " . count( $result->sites ) . ' wpcom sites...</comment>' );
+		$this->output->writeln( "<comment>Searching for '$email' across " . count( $result->sites ) . ' WordPress.com & Jetpack sites...</comment>' );
 
 		// Prepare array with /sites/[siteID]/users/
 		$users_search_urls = array();


### PR DESCRIPTION
Changes:
- Support for `--no-interaction` on `remove-user` command
- "wpcom" text changed to "WordPress.com & Jetpack"
- Also, update ulimit to 4096 on install process to avoid "Too many open files" error

