### PR TITLE
Fixed PHP Deprecated:  Required parameter $bearer_token follows optional parameter

### DIFF
--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -228,7 +228,7 @@ class API_Helper {
 		return json_decode( $result );
 	}
 
-	public function call_generic_api( $api_request_url, $data, $method = 'GET', $bearer_token ) {
+	public function call_generic_api( $api_request_url, $data, $method = 'GET', $bearer_token = null ) {
 		$headers = array(
 			'Accept: application/json',
 			'Content-Type: application/json',


### PR DESCRIPTION
On another convo, it was mentioned that `I tested again and am now getting a bunch of PHP Deprecated notices. FWIW, I'm using php 8.0.3.`

The exact deprecated notice:
```
$ team51-cli % team51 remove-user
Checking for updates..
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=origin/<branch> origin/add/remove-user-from-sites-command



 ______                                ______     _
/\__  _\                              /\  ___\  /' \
\/_/\ \/    __     __      ___ ___    \ \ \__/ /\_, \
   \ \ \  /'__`\ /'__`\  /' __` __`\   \ \___``\/_/\ \
    \ \ \/\  __//\ \L\.\_/\ \/\ \/\ \   \/\ \L\ \ \ \ \
     \ \_\ \____\ \__/.\_\ \_\ \_\ \_\   \ \____/  \ \_\
      \/_/\/____/\/__/\/_/\/_/\/_/\/_/    \/___/    \/_/



PHP Deprecated:  Required parameter $bearer_token follows optional parameter $method in /Users/.../bin/team51-cli/src/helpers/api-helpers.php on line 231

Deprecated: Required parameter $bearer_token follows optional parameter $method in 
```

Fixes #57 