### PR TITLE
Fixing char length error

### DIFF
--- a/src/commands/create-development-site.php
+++ b/src/commands/create-development-site.php
@@ -50,7 +50,7 @@ class Create_Development_Site extends Command {
 			$site_name    = str_replace( '-production', '-development', $pressable_site->data->name );
 			$project_name = str_replace( '-development', '', $site_name );
 		} else {
-			$site_name    = $pressable_site->data->name . '-development';
+      $site_name    = str_replace( '-development', '', $pressable_site->data->name ) . '-development';
 			$project_name = $pressable_site->data->name;
 		}
 
@@ -71,6 +71,16 @@ class Create_Development_Site extends Command {
 				'name' => $site_name,
 			)
 		);
+
+    // catching and displaying useful errors here
+    if ( $pressable_site->errors ) {
+      $site_creation_errors = '';
+      foreach( $pressable_site->errors as $error ) {
+        $site_creation_errors .= $error;
+      }
+      $output->writeln( "<error>Pressable error while creating new site: $site_creation_errors - Aborting!</error>" );
+      exit;
+    }
 
 		// TODO this code is duplicated above
 		if ( empty( $pressable_site->data ) || empty( $pressable_site->data->id ) ) {

--- a/src/commands/create-development-site.php
+++ b/src/commands/create-development-site.php
@@ -47,11 +47,11 @@ class Create_Development_Site extends Command {
 
 		// If the production site was created with this script, follow the same naming convention.
 		if ( false !== strpos( $pressable_site->data->name, '-production' ) ) {
-			$site_name    = str_replace( '-production', '-development', $pressable_site->data->name );
-			$project_name = str_replace( '-development', '', $site_name );
+      $site_name    = str_replace( '-production', '-development', $pressable_site->data->name );
+      $project_name = str_replace( '-development', '', $site_name );
 		} else {
       $site_name    = str_replace( '-development', '', $pressable_site->data->name ) . '-development';
-			$project_name = $pressable_site->data->name;
+      $project_name = $pressable_site->data->name;
 		}
 
 		if ( ! empty( $input->getOption( 'temporary-clone' ) ) ) {


### PR DESCRIPTION
Displaying more verbose pressable errors, and removing redundant site name wording, to reduce chance of hitting 50 char limit.