### PR TITLE
Remove duplicate phpcs checks

### DIFF
--- a/src/commands/create-repository.php
+++ b/src/commands/create-repository.php
@@ -81,9 +81,6 @@ class Create_Repository extends Command {
 			$output->writeln( "<comment>Copying scaffold/templates/phpcs.xml file to scaffold/$slug/phpcs.xml.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/phpcs.xml', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/phpcs.xml" );
 
-			$output->writeln( "<comment>Copying scaffold/templates/github/workflows/phpcs.yml file to scaffold/$slug/github/workflows/phpcs.yml.</comment>" );
-			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/github/workflows/phpcs.yml', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/github/workflows/phpcs.yml" );
-
 			$output->writeln( "<comment>Copying scaffold/templates/deployignore file to scaffold/$slug/.deployignore.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/deployignore', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.deployignore" );
 
@@ -92,7 +89,7 @@ class Create_Repository extends Command {
 			
 			$output->writeln( "<comment>Copying scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders file to scaffold/$slug/.vipgoci_phpcs_skip_folders.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/EXAMPLE-vipgoci_phpcs_skip_folders', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.vipgoci_phpcs_skip_folders" );
-			
+		
 			$output->writeln( "<comment>Copying scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders file to scaffold/$slug/.vipgoci_lint_skip_folders.</comment>" );
 			$filesystem->copy( TEAM51_CLI_ROOT_DIR . '/scaffold/templates/EXAMPLE-vipgoci_lint_skip_folders', TEAM51_CLI_ROOT_DIR . "/scaffold/$slug/.vipgoci_lint_skip_folders" );
 


### PR DESCRIPTION
This PR removes the duplicate phpcs checks on newly created repos.

**Summary**
Duplicate folders with duplicate yml files were being created on new repos, causing the phpcs check to run twice on each commit.

**To Test**
- Create a new repository using the `create-repository` cli command. Example: `team51 create-repository --repo-slug=test-site-ok-to-delete --production-url=test-site-ok-to-delete --create-production-site` 
- Check the newly created repo. Only one `phpcs.yml` file should exist. This will be in the `.github/workflows` folder. No similar folder, such as `github/workflows`, with a `phpcs.yml` file should exist in the repo.

