### PR TITLE
First pass at a `team-51 triage` command.

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -26,5 +26,6 @@ $application->add( new Team51\Command\Front_Create_Export() );
 $application->add( new Team51\Command\Front_List_Exports() );
 $application->add( new Team51\Command\Get_PHP_Errors() );
 $application->add( new Team51\Command\Remove_User() );
+$application->add( new Team51\Command\DevQueue_Triage_Digest() );
 
 $application->run();

--- a/src/commands/devqueue-triage-digest.php
+++ b/src/commands/devqueue-triage-digest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class DevQueue_Triage_Digest extends Command {
+	protected static $defaultName = 'triage';
+
+	protected function configure() {
+		$this
+		->setDescription( 'Generates a Digest Post of what upcoming Triage issues we have.' )
+		->setHelp( 'Scans the triage column to find due dates in the near future.' );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		if ( ! defined( 'GITHUB_DEVQUEUE_TRIAGE_COLUMN' ) ) {
+			$output->writeln( '<error>GITHUB_DEVQUEUE_TRIAGE_COLUMN not set in config.</error>' );
+			return;
+		}
+
+		$api_helper = new API_Helper();
+
+		$output->writeln( '<info>Grabbing Triage Column Items...</info>' );
+
+		$cards = $api_helper->call_github_api(
+			sprintf( 'projects/columns/%s/cards', GITHUB_DEVQUEUE_TRIAGE_COLUMN ),
+			'',
+			'GET'
+		);
+
+		$output->writeln( sprintf( '<comment>Triage currently has %d cards.</comment>', sizeof( $cards ) ) );
+
+		$urgent_issues = array();
+
+		$progress_bar = new ProgressBar( $output, sizeof( $cards ) );
+		$progress_bar->start();
+
+		foreach ( $cards as $card ) {
+			$path = substr( parse_url( $card->content_url, PHP_URL_PATH ), 1 );
+
+			$issue = $api_helper->call_github_api(
+				$path,
+				'',
+				'GET'
+			);
+
+			if ( sizeof( $issue->labels ) ) {
+				foreach ( $issue->labels as $issue_label ) {
+					if ( '[DUE DATE]' === strtoupper( substr( $issue_label->name, 0, 10 ) ) ) {
+						$duedate_timestamp = strtotime( substr( $issue_label->name, 11 ) );
+
+						// If it's due before two days from now ...
+						$issue->due_in = ( $duedate_timestamp - strtotime( 'today' ) ) / ( 24 * 60 * 60 );
+						if ( $issue->due_in <= 2 ) {
+							$urgent_issues[ $issue->id ] = $issue;
+						}
+					}
+				}
+			}
+
+			$progress_bar->advance();
+		}
+
+		$progress_bar->finish();
+		$output->writeln( '' );
+		$output->writeln( '' );
+
+		$output->writeln( sprintf( '<info>Found %d issues pending triage due in the next few days!</info>', sizeof( $urgent_issues ) ) );
+
+		usort( $urgent_issues, function( $a, $b ) {
+			return $a->due_in - $b->due_in;
+		});
+
+		foreach ( $urgent_issues as $issue ) {
+			$type = 'comment';
+			if ( $issue->due_in < 0 ) {
+				$type = 'error';
+			}
+
+			switch( $issue->due_in ) {
+				case -1:
+					$how_long = 'Due YESTERDAY!';
+					break;
+				case '0':
+					$how_long = 'Due TODAY';
+					break;
+				case '1':
+					$how_long = 'Due Tomorrow';
+					break;
+				default:
+					$how_long = "Due in {$issue->due_in} days";
+					break;
+			}
+
+			$output->writeln(
+				sprintf(
+					'<%1$s>* %2$d: [%3$s](%5$s) (%4$s)</%1$s>',
+					$type,
+					$issue->number,
+					$issue->title,
+					$how_long,
+					$issue->html_url
+				)
+			);
+		}
+	}
+}

--- a/src/helpers/config-loader.php
+++ b/src/helpers/config-loader.php
@@ -44,6 +44,14 @@ if( ! empty( $config->GITHUB_API_ENDPOINT ) ) {
 	die();
 }
 
+if ( ! empty( $config->GITHUB_DEVQUEUE_TRIAGE_COLUMN ) ) {
+	define( 'GITHUB_DEVQUEUE_TRIAGE_COLUMN', $config->GITHUB_DEVQUEUE_TRIAGE_COLUMN );
+} else {
+	echo "GITHUB_DEVQUEUE_TRIAGE_COLUMN not set in config.\n";
+	echo "NBD unless you're trying to generate the triage digest.\n";
+	// No need to die() this isn't required for most folks!
+}
+
 if( ! empty( $config->GITHUB_API_TOKEN ) ) {
 	define( 'GITHUB_API_TOKEN', $config->GITHUB_API_TOKEN );
 } else {


### PR DESCRIPTION
To use, you'll need to add a line into your config.json with the triage column id from our workflow board.  Ping @georgestephanis if you need it, but we'll get it merged in if this lands for everyone to use.