### PR TITLE
Add feature to list plugins on a site.

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -27,5 +27,6 @@ $application->add( new Team51\Command\Front_Get_Export() );
 $application->add( new Team51\Command\Get_PHP_Errors() );
 $application->add( new Team51\Command\Remove_User() );
 $application->add( new Team51\Command\DevQueue_Triage_Digest() );
+$application->add( new Team51\Command\Plugin_List() );
 
 $application->run();

--- a/src/commands/plugin-list.php
+++ b/src/commands/plugin-list.php
@@ -10,24 +10,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 
 class Plugin_List extends Command {
-    protected static $defaultName = 'plugin-list';
+	protected static $defaultName = 'plugin-list';
 
-    protected function configure() {
-        $this
-        ->setDescription( "Shows list of plugins on a specified site." )
-		->setHelp( "Use this command to show a list of installed plugins on a site. This command requires a Jetpack site connected to the a8cteam51 account." )
-		->addArgument( 'site-domain', InputArgument::REQUIRED, "The domain of the Jetpack connected site." );
-    }
+	protected function configure() {
+		$this
+		->setDescription( 'Shows list of plugins on a specified site.' )
+		->setHelp( 'Use this command to show a list of installed plugins on a site. This command requires a Jetpack site connected to the a8cteam51 account.' )
+		->addArgument( 'site-domain', InputArgument::REQUIRED, 'The domain of the Jetpack connected site.' );
+	}
 
-    protected function execute( InputInterface $input, OutputInterface $output ) {
+	protected function execute( InputInterface $input, OutputInterface $output ) {
 		$site_domain = $input->getArgument( 'site-domain' );
 
 		$api_helper = new API_Helper;
 
-		$output->writeln( '<info>Fetching site information...<info>' );
-
 		$site = $api_helper->call_wpcom_api( 'rest/v1.1/sites/' . $site_domain, array() );
-		//var_dump ( $site );
 
 		if ( empty( $site->ID ) ) {
 			$output->writeln( '<error>Failed to fetch site information.<error>' );
@@ -35,14 +32,9 @@ class Plugin_List extends Command {
 			exit;
 		}
 
-		$output->writeln( '<info>Getting list of plugins...<info>' );
+		$output->writeln( "<info>Plugins installed on {$site_domain}<info>" );
 
-		$data = array(
-			//'path' => '/jetpack/v4/plugins',
-		);
-		//var_dump( $data );
-		$plugin_data = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site->ID . '/rest-api/?path=/jetpack/v4/plugins', $data );
-		//var_dump( $result );
+		$plugin_data = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site->ID . '/rest-api/?path=/jetpack/v4/plugins', array() );
 
 		if ( ! empty( $plugin_data->error ) ) {
 			$output->writeln( '<error>Failed. ' . $result->message . '<error>' );
@@ -55,12 +47,11 @@ class Plugin_List extends Command {
 
 		$plugin_list = array();
 		foreach ( $plugin_data->data as $plugin ) {
-				$plugin_list[] = array( $plugin->TextDomain, ($plugin->active ? 'Active' : 'Inactive'), $plugin->Version );
-			}
+				$plugin_list[] = array( $plugin->TextDomain, ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
+		}
 
 		$plugin_table->setRows( $plugin_list );
 		$plugin_table->render();
 
-		$output->writeln( '<info>All done! :)<info>' );
-    }
+	}
 }

--- a/src/commands/plugin-list.php
+++ b/src/commands/plugin-list.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+class Plugin_List extends Command {
+    protected static $defaultName = 'plugin-list';
+
+    protected function configure() {
+        $this
+        ->setDescription( "Shows list of plugins on a specified site." )
+		->setHelp( "Use this command to show a list of installed plugins on a site. This command requires a Jetpack site connected to the a8cteam51 account." )
+		->addArgument( 'site-domain', InputArgument::REQUIRED, "The domain of the Jetpack connected site." );
+    }
+
+    protected function execute( InputInterface $input, OutputInterface $output ) {
+		$site_domain = $input->getArgument( 'site-domain' );
+
+		$api_helper = new API_Helper;
+
+		$output->writeln( '<info>Fetching site information...<info>' );
+
+		$site = $api_helper->call_wpcom_api( 'rest/v1.1/sites/' . $site_domain, array() );
+		//var_dump ( $site );
+
+		if ( empty( $site->ID ) ) {
+			$output->writeln( '<error>Failed to fetch site information.<error>' );
+			$output->writeln( '<info>Are you sure this site is connected to Jetpack and on the a8cteam51 account?<info>' );
+			exit;
+		}
+
+		$output->writeln( '<info>Getting list of plugins...<info>' );
+
+		$data = array(
+			//'path' => '/jetpack/v4/plugins',
+		);
+		//var_dump( $data );
+		$plugin_data = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site->ID . '/rest-api/?path=/jetpack/v4/plugins', $data );
+		//var_dump( $result );
+
+		if ( ! empty( $plugin_data->error ) ) {
+			$output->writeln( '<error>Failed. ' . $result->message . '<error>' );
+			exit;
+		}
+
+		$plugin_table = new Table( $output );
+		$plugin_table->setStyle( 'box-double' );
+		$plugin_table->setHeaders( array( 'Plugin slug', 'Status', 'Version' ) );
+
+		$plugin_list = array();
+		foreach ( $plugin_data->data as $plugin ) {
+				$plugin_list[] = array( $plugin->TextDomain, ($plugin->active ? 'Active' : 'Inactive'), $plugin->Version );
+			}
+
+		$plugin_table->setRows( $plugin_list );
+		$plugin_table->render();
+
+		$output->writeln( '<info>All done! :)<info>' );
+    }
+}


### PR DESCRIPTION
### Changes Proposed in this Pull Request

Add a new command to list the installed plugins on Team 51 managed sites. 

Note: Sites must have a healthy Jetpack connection for this to work.

#### Testing Instructions

- From your `team51-cli` folder in a new terminal window, switch to this branch using `git checkout feature/plugin-list`.
- Test the command on your favorite Team 51 managed site, eg. `team51 plugin-list www.heyshayla.com`.
- Note the subdomain. If the site's primary domain includes the `www`, this needs to be added.
- If you receive an error, the site is most likely not Jetpack connected, our there's an issue with the connection. 

