### PR TITLE
Fix Plugin display with no slugs.

### DIFF
--- a/src/commands/plugin-list.php
+++ b/src/commands/plugin-list.php
@@ -47,7 +47,7 @@ class Plugin_List extends Command {
 
 		$plugin_list = array();
 		foreach ( $plugin_data->data as $plugin ) {
-				$plugin_list[] = array( $plugin->TextDomain, ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
+				$plugin_list[] = array( ( empty( $plugin->TextDomain ) ? $plugin->Name  . ' - (No slug)' : $plugin->TextDomain ), ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
 		}
 
 		$plugin_table->setRows( $plugin_list );

--- a/src/commands/plugin-list.php
+++ b/src/commands/plugin-list.php
@@ -49,6 +49,7 @@ class Plugin_List extends Command {
 		foreach ( $plugin_data->data as $plugin ) {
 				$plugin_list[] = array( ( empty( $plugin->TextDomain ) ? $plugin->Name  . ' - (No slug)' : $plugin->TextDomain ), ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
 		}
+		asort( $plugin_list );
 
 		$plugin_table->setRows( $plugin_list );
 		$plugin_table->render();


### PR DESCRIPTION
The intent of the `plugin-list` command is to mimic the wp-cli "plugin list" command - which returns the list of plugin slugs. Unfortunately, the plugin slug, or the "Text Domain" in the plugin header, is optional, and not always present. As a result, plugins with no "Text Domain" defined show as a blank line in the list of plugins. 

This PR adds a conditional to the output to use the plugin "Name" in cases where the Text Domain is empty.

This PR also sorts the plugins alphabetically, as this makes it easier to scan through the list.

