### PR TITLE
Add Jetpack site module status command

### DIFF
--- a/config__contractor.json
+++ b/config__contractor.json
@@ -1,0 +1,11 @@
+{
+    "PRESSABLE_API_ENDPOINT": "https://my.pressable.com/v1/",
+    "PRESSABLE_API_TOKEN_ENDPOINT": "https://my.pressable.com/auth/token",
+    "PRESSABLE_BOT_COLLABORATOR_EMAIL": "concierge+cli@a8c.com",
+    "PRESSABLE_BOT_COLLABORATOR_ACCOUNT_ID": "1412875",
+    "ASCII_WELCOME_ART": "\n ______                                ______     _\n/\\__  _\\                              /\\  ___\\  /' \\\n\\/_/\\ \\/    __     __      ___ ___    \\ \\ \\__/ /\\_, \\\n   \\ \\ \\  /'__`\\ /'__`\\  /' __` __`\\   \\ \\___``\\/_/\\ \\\n    \\ \\ \\/\\  __//\\ \\L\\.\\_/\\ \\/\\ \\/\\ \\   \\/\\ \\L\\ \\ \\ \\ \\\n     \\ \\_\\ \\____\\ \\__/.\\_\\ \\_\\ \\_\\ \\_\\   \\ \\____/  \\ \\_\\\n      \\/_/\\/____/\\/__/\\/_/\\/_/\\/_/\\/_/    \\/___/    \\/_/\n\n\n",
+
+    "PRESSABLE_API_APP_CLIENT_ID":"Ut_XiqyWqMTsighUa6Z0PYd3df0yGyak5ySM_NuUc9w",
+    "PRESSABLE_API_APP_CLIENT_SECRET":"BypoQA6adyO-xFud7kOkp4cjt_NScUosZVSvlLCRZ-M",
+    "PRESSABLE_API_REFRESH_TOKEN":"FUMpT2TRhjRMCJzBZBzAN-Q2zkU-qU_AqwHF2a5drjg"
+}

--- a/load-application.php
+++ b/load-application.php
@@ -32,6 +32,6 @@ $application->add( new Team51\Command\Plugin_List() );
 $application->add( new Team51\Command\Pressable_Generate_Token() );
 $application->add( new Team51\Command\Pressable_Grant_Access() );
 $application->add( new Team51\Command\Pressable_Call_Api() );
-
+$application->add( new Team51\Command\Jetpack_Modules() );
 
 $application->run();

--- a/src/commands/jetpack-module-list.php
+++ b/src/commands/jetpack-module-list.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 
 class Jetpack_Modules extends Command {
-	protected static $defaultName = 'jetpack-modules';
+	protected static $defaultName = 'jetpack-module-list';
 
 	protected function configure() {
 		$this

--- a/src/commands/jetpack-modules.php
+++ b/src/commands/jetpack-modules.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+class Jetpack_Modules extends Command {
+	protected static $defaultName = 'jetpack-modules';
+
+	protected function configure() {
+		$this
+		->setDescription( 'Shows status of Jetpack modules on a specified site.' )
+		->setHelp( 'Use this command to show a list of Jetpack modules on a site, and their status. This command requires a Jetpack site connected to the a8cteam51 account.' )
+		->addArgument( 'site-domain', InputArgument::REQUIRED, 'The domain of the Jetpack connected site.' );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$site_domain = $input->getArgument( 'site-domain' );
+
+		$api_helper = new API_Helper;
+
+		$site = $api_helper->call_wpcom_api( 'rest/v1.1/sites/' . $site_domain, array() );
+
+		if ( empty( $site->ID ) ) {
+			$output->writeln( '<error>Failed to fetch site information.<error>' );
+			$output->writeln( '<info>Are you sure this site is connected to Jetpack and on the a8cteam51 account?<info>' );
+			exit;
+		}
+
+		$output->writeln( "<info>Jetpack module status for {$site_domain}<info>" );
+
+		$module_data = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site->ID . '/rest-api/?path=/jetpack/v4/module/all', array() );
+
+		if ( ! empty( $module_data->error ) ) {
+			$output->writeln( '<error>Failed. ' . $result->message . '<error>' );
+			exit;
+		}
+
+		$module_table = new Table( $output );
+		$module_table->setStyle( 'box-double' );
+		$module_table->setHeaders( array( 'Module', 'Status' ) );
+
+		$module_list = array();
+		foreach ( $module_data->data as $module ) {
+				$module_list[] = array( $module->module, ( $module->activated ? 'Active' : 'Inactive' ) );
+		}
+		asort( $module_list );
+
+		$module_table->setRows( $module_list );
+		$module_table->render();
+
+	}
+}

--- a/src/commands/jetpack-modules.php
+++ b/src/commands/jetpack-modules.php
@@ -47,7 +47,7 @@ class Jetpack_Modules extends Command {
 
 		$module_list = array();
 		foreach ( $module_data->data as $module ) {
-				$module_list[] = array( $module->module, ( $module->activated ? 'Active' : 'Inactive' ) );
+				$module_list[] = array( $module->module, ( $module->activated ? 'on' : 'off' ) );
 		}
 		asort( $module_list );
 

--- a/src/commands/jetpack-modules.php
+++ b/src/commands/jetpack-modules.php
@@ -24,7 +24,7 @@ class Jetpack_Modules extends Command {
 
 		$api_helper = new API_Helper;
 
-		$site = $api_helper->call_wpcom_api( 'rest/v1.1/sites/' . $site_domain, array() );
+		$site = $api_helper->call_wpcom_api( 'rest/v1.1/sites/' . $site_domain . '?fields=ID', array() );
 
 		if ( empty( $site->ID ) ) {
 			$output->writeln( '<error>Failed to fetch site information.<error>' );


### PR DESCRIPTION
### Changes Proposed in this Pull Request
Add a new command to list the status of all Jetpack modules on a Jetpack connected site.

Note: Sites must have a healthy Jetpack connection for this to work.

**Testing Instructions**
From your `team51-cli` folder in a new terminal window, switch to this branch using `git checkout feature/jetpack-module-list`.
Test the command on your favorite Team 51 managed site, eg. `team51 jetpack-module-list www.heyshayla.com`.
Note the subdomain. If the site's primary domain includes the `www`, this needs to be used.
If you receive an error, the site is most likely not Jetpack connected, or there's an issue with the connection.