### PR TITLE
Incorrect variable name reference in error response

### DIFF
--- a/src/commands/plugin-list.php
+++ b/src/commands/plugin-list.php
@@ -37,7 +37,7 @@ class Plugin_List extends Command {
 		$plugin_data = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site->ID . '/rest-api/?path=/jetpack/v4/plugins', array() );
 
 		if ( ! empty( $plugin_data->error ) ) {
-			$output->writeln( '<error>Failed. ' . $result->message . '<error>' );
+			$output->writeln( '<error>Failed. ' . $plugin_data->message . '<error>' );
 			exit;
 		}
 
@@ -47,7 +47,7 @@ class Plugin_List extends Command {
 
 		$plugin_list = array();
 		foreach ( $plugin_data->data as $plugin ) {
-				$plugin_list[] = array( ( empty( $plugin->TextDomain ) ? $plugin->Name  . ' - (No slug)' : $plugin->TextDomain ), ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
+				$plugin_list[] = array( ( empty( $plugin->TextDomain ) ? $plugin->Name . ' - (No slug)' : $plugin->TextDomain ), ( $plugin->active ? 'Active' : 'Inactive' ), $plugin->Version );
 		}
 		asort( $plugin_list );
 


### PR DESCRIPTION
### Changes Proposed in this Pull Request

In rare cases when a site's Jetpack connection is not healthy, the response from the call for plugin information may contain an error message. The code was attempting to display that error message for the user, however the variable name used to extract the error message was incorrect. This PR fixes the issue by setting the correct variable name.

#### Testing Instructions
Hmm, this is tricky. Testing requires an unstable Jetpack connection, or a recently disconnected Jetpack site. Since simulating the specific conditions for an unstable Jetpack connection is near impossible, the closest alternative would be to deactivate the Jetpack plugin on a site with a healthy connection.
Test using the command `team51 plugin-list mysite.com`. 
The result should not include any PHP error messages, and instead include the text "Failed" followed by the response error message.

This fixes #80 

