### PR TITLE
Stop WP User creation with php-errors command

### DIFF
--- a/src/commands/php-errors.php
+++ b/src/commands/php-errors.php
@@ -88,7 +88,6 @@ class Get_PHP_Errors extends Command {
             $output->writeln( "<error>Error creating temporary bot collaborator. Aborting!</error>" );
             exit;
         }
-        //sleep(10);
         // Get new collaborator id.
         $max_tries = 0;
         while ( empty( $collaborator_id ) || 3 >= $max_tries ) {

--- a/src/commands/php-errors.php
+++ b/src/commands/php-errors.php
@@ -101,12 +101,11 @@ class Get_PHP_Errors extends Command {
             foreach ( $get_collaborator_list->data as $collaborator ) {
                 if ( PRESSABLE_BOT_COLLABORATOR_EMAIL === $collaborator->email ) {
                     $collaborator_id = $collaborator->id;
-                    break;
-                } else {
-                    sleep( 1 );
-                    $max_tries++;
+                    break( 2 );
                 }
             }
+            sleep( 1 );
+            $max_tries++;
         }
 
         if ( empty( $collaborator_id ) ) {

--- a/src/commands/php-errors.php
+++ b/src/commands/php-errors.php
@@ -89,8 +89,10 @@ class Get_PHP_Errors extends Command {
             exit;
         }
         // Get new collaborator id.
-        $max_tries = 0;
-        while ( empty( $collaborator_id ) || 3 >= $max_tries ) {
+        $tries           = 0;
+        $delay           = 1;
+        $collaborator_id = null;
+        while ( empty( $collaborator_id ) || $tries <= 3 ) {
 
             $get_collaborator_list = $api_helper->call_pressable_api(
                     "/sites/{$pressable_site->id}/collaborators",
@@ -104,13 +106,13 @@ class Get_PHP_Errors extends Command {
                     break( 2 );
                 }
             }
-            sleep( 1 );
-            $max_tries++;
+            sleep( $delay );
+            $tries++;
+            $delay = $delay * 2;
         }
 
         if ( empty( $collaborator_id ) ) {
-            $output->writeln( "<error>Error finding temporary bot collaborator. Aborting!</error>" );
-            exit;
+            $output->writeln( "<error>Trouble finding temporary bot collaborator, may need to be removed manually.</error>" );
         }
 
         $output->writeln( "<comment>Getting bot collaborator SFTP credentials.</comment>" );
@@ -169,6 +171,10 @@ class Get_PHP_Errors extends Command {
             'DELETE',
             array()
         );
+
+        if ( is_null( $collaborator_id ) ) {
+            $output->writeln( "<error>Unable to remove temporary bot collaborator. Please remove manually.</error>" );
+        }
 
         // If they asked for the raw log, give it to them and bail.
         if ( ! empty( $input->getOption( 'raw' ) ) ) {


### PR DESCRIPTION
### Changes Proposed in this Pull Request

The current `php-errors` command automatically creates a WordPress user on any site the tool tries to access. This PR limits the temporary collaborator to only SFTP access by changing the API end-point from `/sites/{site_id}/collaborators` to the `/collaborators/batch_create` end-point, [explained here](https://my.pressable.com/documentation/api/v1#collaborator-bulk-create), and no longer creates a user in wp-admin/on the site.

To make this happen, I made the following changes:

- I changed the API endpoint we were using from `sites`, to `collaborators` to be able to use the bulk creation option. This is the only option that limits access requirements, and is the key to creating a user with only SFTP Access (and not creating a user on the site). [New code](https://github.com/Automattic/team51-cli/blob/b365847d3eb2ef40ec5256faac1ec6305cf0dc20/src/commands/php-errors.php#L75-L85), [old code](https://github.com/Automattic/team51-cli/blob/82f5b3deb57d28581a640b28af416faebe5be1d5/src/commands/php-errors.php#L75-L82).
- This endpoint comes with a downside, it doesn't return the `accountID`, so I had to add another step to get the newly created accountID (for use later on to delete the user). Additionally, I found that if I query the collaborator list too quickly after creating the user, the new user isn't returned in the list. A short delay fixed that, but to prevent waiting unnecessarily I created a small loop with a try limit and a one-second delay after each attempt. That [code is here](https://github.com/Automattic/team51-cli/blob/69609b77b58b064f5e41d1ac587bd58559f143b9/src/commands/php-errors.php#L92-L109). In testing, the new accountID was included in the response on the second attempt on every test I ran.
- I also made another change to the code that's not associated with this new functionality. In the original code we grab the SFTP user ID by simply [looking for the highest numerical value of the ID ](https://github.com/Automattic/team51-cli/blob/82f5b3deb57d28581a640b28af416faebe5be1d5/src/commands/php-errors.php#L99)- assuming this is the user we just created. Probably ok 99.99% of the time. I've made this line redundant (and removed it) by instead comparing against the SFTP user email address to confirm which is our correct SFTP user. New [conditional check](https://github.com/Automattic/team51-cli/blob/b365847d3eb2ef40ec5256faac1ec6305cf0dc20/src/commands/php-errors.php#L131), [old conditional check](https://github.com/Automattic/team51-cli/blob/82f5b3deb57d28581a640b28af416faebe5be1d5/src/commands/php-errors.php#L104).

#### Testing Instructions

- Run the command on any site using `team51 php-errors anysite.com`.
- Check the WordPress site's users section - there should be no user added to the site.
- Check the site's dashboard in wp-admin, under the "Users" section - the temporary user should not be visible (and hence not created).



