### PR TITLE
Self provision access to Pressable

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -30,5 +30,7 @@ $application->add( new Team51\Command\DevQueue_Triage_Digest() );
 $application->add( new Team51\Command\Update_Repository_Secret() );
 $application->add( new Team51\Command\Plugin_List() );
 $application->add( new Team51\Command\Pressable_Generate_Token() );
+$application->add( new Team51\Command\Pressable_Grant_Access() );
+
 
 $application->run();

--- a/src/commands/pressable-generate-token.php
+++ b/src/commands/pressable-generate-token.php
@@ -17,7 +17,7 @@ class Pressable_Generate_Token extends Command {
 	protected function configure() {
 		$this
 		->setDescription( 'Generates a Pressable token based on Client ID and Client Secret, to be used on config.json' )
-		->setHelp( 'Requires --client_id and --client_secret. This command allows you to generate a Pressable OAuth token for a given API Application Client ID and Client Secret. This allows external collaborators to have access to Pressable functionality using Team51 CLI.' )
+		->setHelp( 'Requires --client_id and --client_secret. This command allows you to generate a Pressable OAuth token for a given API Application Client ID and Client Secret. This allows outside collaborators to have access to Pressable functionality using Team51 CLI.' )
 		->addOption( 'client_id', null, InputOption::VALUE_REQUIRED, "The Client ID." )
 		->addOption( 'client_secret', null, InputOption::VALUE_REQUIRED, "The Client Secret." );
 	}
@@ -49,7 +49,7 @@ class Pressable_Generate_Token extends Command {
 
 		$tokens = $this->api_helper->get_pressable_api_auth_tokens( $client_id, $client_secret );
 
-		$output->writeln( "<info>\nProvide the following lines to the external collaborator. These should be placed on their config.json file:\n</info>" );
+		$output->writeln( "<info>\nProvide the following lines to the outside collaborator. These should be placed on their config.json file:\n</info>" );
 
 		$output->writeln( '"PRESSABLE_API_APP_CLIENT_ID":"' . $client_id . '",' );
 		$output->writeln( '"PRESSABLE_API_APP_CLIENT_SECRET":"' . $client_secret . '",' );

--- a/src/commands/pressable-grant-access.php
+++ b/src/commands/pressable-grant-access.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Team51\Command;
+
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Pressable_Grant_Access extends Command {
+	protected static $defaultName = 'pressable-grant-access';
+	private $api_helper;
+	private $output;
+
+	protected function configure() {
+		$this
+		->setDescription( 'Grants user access to a Pressable site' )
+		->setHelp( 'Requires --client_id and --client_secret. This command allows you to generate a Pressable OAuth token for a given API Application Client ID and Client Secret. This allows external collaborators to have access to Pressable functionality using Team51 CLI.' )
+		->addOption( 'email', null, InputOption::VALUE_REQUIRED, "The user email." )
+		->addOption( 'site', null, InputOption::VALUE_REQUIRED, "The Pressable site. Can be a numeric site ID or by domain." );
+	}
+
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$this->api_helper = new API_Helper();
+		$this->output     = $output;
+
+		$email = $input->getOption( 'email' );
+		$site = $input->getOption( 'site' );
+
+		if ( empty( $email ) ) {
+			$email = trim( readline( 'Please enter the email: ' ) );
+			if ( empty( $email ) ) {
+				$output->writeln( '<error>Missing email (--email=someone@a8c.com).</error>' );
+				exit;
+			}
+		}
+
+		if ( empty( $site ) ) {
+			$site = trim( readline( 'Please enter the site: ' ) );
+			if ( empty( $site ) ) {
+				$output->writeln( '<error>Missing site (--site=my-webiste.com).</error>' );
+				exit;
+			}
+		}
+
+		$output->writeln( '<comment>Granting ' . $email . ' access to site ' . $site . '.</comment>' );
+
+		$site_id;
+		if ( is_numeric( $site ) ) {
+			$site_id = $site;
+		} else {
+			$search_site = $this->api_helper->call_pressable_api( sprintf('sites?per_page=5&tag_name=%s', $site), 'GET', array() );
+			var_dump($search_site);
+			// TODO: loop and find site_id by domain
+		}
+
+		// Note: batch_create is needed because it's the only way to assign sftp_access roles to the new user
+		// POST /sites/{site_id}/collaborators would be a better fit if it allowed the `roles` parame
+		$async_result = $this->api_helper->call_pressable_api(
+			'collaborators/batch_create',
+			'POST',
+			array(
+				'email' => $email,
+				'siteIds' => [$site],
+				'roles' => [ 'clone_site', 'sftp_access', 'download_backups', 'reset_collaborator_password', 'wp_access' ]
+			)
+		);
+
+		if ( $async_result->errors === NULL ) {
+			$output->writeln( "<info>\nCollaborator added to the site. Pressable says: {$async_result->message}<info>" );
+		} else {
+			$output->writeln( "<error>\nSomething went wrong while running collaborators/batch_create! Message: {$async_result->message}<error>" );
+		}
+
+
+		$output->writeln( "<info>\nAll done!<info>" );
+	}
+}

--- a/src/helpers/config-loader.php
+++ b/src/helpers/config-loader.php
@@ -3,6 +3,7 @@
 namespace Team51\Helper;
 
 $config = json_decode( file_get_contents( TEAM51_CLI_ROOT_DIR . '/config.json' ) );
+$warning_config_keys = array();
 
 if( empty( $config ) ) {
 	echo "Config file couldn't be read. Aborting!\n";
@@ -12,104 +13,89 @@ if( empty( $config ) ) {
 if( ! empty( $config->DEPLOY_HQ_API_KEY ) ) {
 	define( 'DEPLOY_HQ_API_KEY', $config->DEPLOY_HQ_API_KEY );
 } else {
-	echo "DEPLOY_HQ_API_KEY could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "DEPLOY_HQ_API_KEY";
 }
 
 if( ! empty( $config->DEPLOY_HQ_USERNAME ) ) {
 	define( 'DEPLOY_HQ_USERNAME', $config->DEPLOY_HQ_USERNAME );
 } else {
-	echo "DEPLOY_HQ_USERNAME could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "DEPLOY_HQ_USERNAME";
 }
 
 if( ! empty( $config->DEPLOY_HQ_API_ENDPOINT ) ) {
 	define( 'DEPLOY_HQ_API_ENDPOINT', $config->DEPLOY_HQ_API_ENDPOINT );
 } else {
-	echo "DEPLOY_HQ_API_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "DEPLOY_HQ_API_ENDPOINT";
 }
 
 if( ! empty( $config->GITHUB_API_OWNER ) ) {
 	define( 'GITHUB_API_OWNER', $config->GITHUB_API_OWNER );
 } else {
-	echo "GITHUB_API_OWNER could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "GITHUB_API_OWNER";
 }
 
 if( ! empty( $config->GITHUB_API_ENDPOINT ) ) {
 	define( 'GITHUB_API_ENDPOINT', $config->GITHUB_API_ENDPOINT );
 } else {
-	echo "GITHUB_API_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "GITHUB_API_ENDPOINT";
 }
 
 if ( ! empty( $config->GITHUB_DEVQUEUE_TRIAGE_COLUMN ) ) {
 	define( 'GITHUB_DEVQUEUE_TRIAGE_COLUMN', $config->GITHUB_DEVQUEUE_TRIAGE_COLUMN );
 } else {
-	echo "GITHUB_DEVQUEUE_TRIAGE_COLUMN not set in config.\n";
-	echo "NBD unless you're trying to generate the triage digest.\n";
-	// No need to die() this isn't required for most folks!
+	$warning_config_keys[] = "GITHUB_DEVQUEUE_TRIAGE_COLUMN";
 }
 
 if( ! empty( $config->GITHUB_API_TOKEN ) ) {
 	define( 'GITHUB_API_TOKEN', $config->GITHUB_API_TOKEN );
 } else {
-	echo "GITHUB_API_TOKEN could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "GITHUB_API_TOKEN";
 }
 
 if( ! empty( $config->PRESSABLE_SFTP_HOSTNAME ) ) {
 	define( 'PRESSABLE_SFTP_HOSTNAME', $config->PRESSABLE_SFTP_HOSTNAME );
 } else {
-	echo "PRESSABLE_SFTP_HOSTNAME could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_SFTP_HOSTNAME";
 }
 if( ! empty( $config->PRESSABLE_SFTP_USERNAME ) ) {
 	define( 'PRESSABLE_SFTP_USERNAME', $config->PRESSABLE_SFTP_USERNAME );
 } else {
-	echo "PRESSABLE_SFTP_USERNAME could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_SFTP_USERNAME";
 }
 
 if( ! empty( $config->PRESSABLE_SFTP_PASSWORD ) ) {
 	define( 'PRESSABLE_SFTP_PASSWORD', $config->PRESSABLE_SFTP_PASSWORD );
 } else {
-	echo "PRESSABLE_SFTP_PASSWORD could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_SFTP_PASSWORD";
 }
 
 if( ! empty( $config->PRESSABLE_API_ENDPOINT ) ) {
 	define( 'PRESSABLE_API_ENDPOINT', $config->PRESSABLE_API_ENDPOINT );
 } else {
-	echo "PRESSABLE_API_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_API_ENDPOINT";
 }
 
 if( ! empty( $config->PRESSABLE_API_TOKEN_ENDPOINT ) ) {
 	define( 'PRESSABLE_API_TOKEN_ENDPOINT', $config->PRESSABLE_API_TOKEN_ENDPOINT );
 } else {
-	echo "PRESSABLE_API_TOKEN_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_API_TOKEN_ENDPOINT";
 }
 
 if( ! empty( $config->PRESSABLE_API_APP_CLIENT_ID ) ) {
 	define( 'PRESSABLE_API_APP_CLIENT_ID', $config->PRESSABLE_API_APP_CLIENT_ID );
 } else {
-	echo "PRESSABLE_API_APP_CLIENT_ID could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_API_APP_CLIENT_ID";
 }
 
 if( ! empty( $config->PRESSABLE_API_APP_CLIENT_SECRET ) ) {
 	define( 'PRESSABLE_API_APP_CLIENT_SECRET', $config->PRESSABLE_API_APP_CLIENT_SECRET );
 } else {
-	echo "PRESSABLE_API_APP_CLIENT_SECRET could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_API_APP_CLIENT_SECRET";
 }
 
 if( empty( $config->PRESSABLE_ACCOUNT_EMAIL ) && empty( $config->PRESSABLE_API_REFRESH_TOKEN ) ) {
-	echo "Neither PRESSABLE_ACCOUNT_EMAIL or PRESSABLE_API_REFRESH_TOKEN could be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_ACCOUNT_EMAIL";
+	$warning_config_keys[] = "PRESSABLE_API_REFRESH_TOKEN";
 } else {
 	if ( ! empty( $config->PRESSABLE_ACCOUNT_EMAIL ) ) {
 		define( 'PRESSABLE_ACCOUNT_EMAIL', $config->PRESSABLE_ACCOUNT_EMAIL );
@@ -120,8 +106,8 @@ if( empty( $config->PRESSABLE_ACCOUNT_EMAIL ) && empty( $config->PRESSABLE_API_R
 }
 
 if( empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) && empty( $config->PRESSABLE_API_REFRESH_TOKEN ) ) {
-	echo "Neither PRESSABLE_ACCOUNT_PASSWORD or PRESSABLE_API_REFRESH_TOKEN could be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "PRESSABLE_ACCOUNT_PASSWORD";
+	$warning_config_keys[] = "PRESSABLE_API_REFRESH_TOKEN";
 } else {
 	if ( ! empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) ) {
 		define( 'PRESSABLE_ACCOUNT_PASSWORD', $config->PRESSABLE_ACCOUNT_PASSWORD );
@@ -131,57 +117,57 @@ if( empty( $config->PRESSABLE_ACCOUNT_PASSWORD ) && empty( $config->PRESSABLE_AP
 if( ! empty( $config->WPCOM_API_ENDPOINT ) ) {
 	define( 'WPCOM_API_ENDPOINT', $config->WPCOM_API_ENDPOINT );
 } else {
-	echo "Warning: WPCOM_API_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "WPCOM_API_ENDPOINT";
 }
 
 if( ! empty( $config->WPCOM_API_ACCOUNT_TOKEN ) ) {
 	define( 'WPCOM_API_ACCOUNT_TOKEN', $config->WPCOM_API_ACCOUNT_TOKEN );
 } else {
-	echo "Warning: WPCOM_API_ACCOUNT_TOKEN could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "WPCOM_API_ACCOUNT_TOKEN";
 }
 
 if( ! empty( $config->FRONT_API_ENDPOINT ) ) {
 	define( 'FRONT_API_ENDPOINT', $config->FRONT_API_ENDPOINT );
 } else {
-	echo "Warning: FRONT_API_ENDPOINT could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "FRONT_API_ENDPOINT";
 }
 
 if( ! empty( $config->FRONT_API_TOKEN ) ) {
 	define( 'FRONT_API_TOKEN', $config->FRONT_API_TOKEN );
 } else {
-	echo "Warning: FRONT_API_TOKEN could not be set. Aborting!\n";
-	die();
+	$warning_config_keys[] = "FRONT_API_TOKEN";
 }
 
 if( ! empty( $config->SLACK_WEBHOOK_URL ) ) {
 	define( 'SLACK_WEBHOOK_URL', $config->SLACK_WEBHOOK_URL );
 } else {
-	echo "Warning: SLACK_WEBHOOK_URL could not be set.\n";
+	$warning_config_keys[] = "SLACK_WEBHOOK_URL";
 }
 
 if( ! empty( $config->GITHUB_TEAM_TO_ADD_TO_NEW_REPOSITORY ) ) {
 	define( 'GITHUB_TEAM_TO_ADD_TO_NEW_REPOSITORY', $config->GITHUB_TEAM_TO_ADD_TO_NEW_REPOSITORY );
 } else {
-	echo "Warning: GITHUB_TEAM_TO_ADD_TO_NEW_REPOSITORY could not be set.\n";
+	$warning_config_keys[] = "GITHUB_TEAM_TO_ADD_TO_NEW_REPOSITORY";
 }
 
 if( ! empty( $config->ASCII_WELCOME_ART ) ) {
 	define( 'ASCII_WELCOME_ART', $config->ASCII_WELCOME_ART );
 } else {
-	echo "Warning: ASCII_WELCOME_ART could not be set.\n";
+	$warning_config_keys[] = "ASCII_WELCOME_ART";
 }
 
 if( ! empty( $config->GITHUB_DEFAULT_ISSUES_REPOSITORY ) ) {
 	define( 'GITHUB_DEFAULT_ISSUES_REPOSITORY', $config->GITHUB_DEFAULT_ISSUES_REPOSITORY );
 } else {
-	echo "Warning: GITHUB_DEFAULT_ISSUES_REPOSITORY could not be set.\n";
+	$warning_config_keys[] = "GITHUB_DEFAULT_ISSUES_REPOSITORY";
 }
 
 if( ! empty( $config->PRESSABLE_BOT_COLLABORATOR_EMAIL ) ) {
 	define( 'PRESSABLE_BOT_COLLABORATOR_EMAIL', $config->PRESSABLE_BOT_COLLABORATOR_EMAIL );
 } else {
-	echo "Warning: PRESSABLE_BOT_COLLABORATOR_EMAIL could not be set.\n";
+	$warning_config_keys[] = "PRESSABLE_BOT_COLLABORATOR_EMAIL";
+}
+
+if ( ! empty( $warning_config_keys ) ) {
+	echo "WARNING: The following values were not found in config.json, some commands might not work as expected: " . implode( ", ", $warning_config_keys );
 }


### PR DESCRIPTION
This update allows a CLI user to add a collaborator to a Pressable site.

The parameters received by the command are:
 - email address
 - site (which can be either a numerical site ID or a domain)

This action can be performed by a limited-access user like outside collaborators/contractors to self-provision access to Pressable sites, as long as they have a `PRESSABLE_API_REFRESH_TOKEN` defined on their config.json

Because it can be used by limited-access users, most of the constants required in config.json are now optional. If certain config key/values are missing, rather than terminating the session, the CLI will now display a warning message.

Example of how to use this command:
```
team51 pressable-grant-access --email=ecairol@gmail.com --site=esteban-sandbox.mystagingwebsite.com
```

<img width="1134" alt="Screen Shot 2022-04-27 at 13 34 35" src="https://user-images.githubusercontent.com/1821060/165608855-5c828712-86e7-4d97-ae96-de2ef72073e0.png">
<img width="1116" alt="Screen Shot 2022-04-27 at 13 37 20" src="https://user-images.githubusercontent.com/1821060/165609293-a95e4a10-b131-4cb7-ba48-cba89f23e5fb.png">
