### PR TITLE
Feature/1167 improve cli php errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.json
 vendor/
 .DS_Store
 src/helpers/pressable_token.json
+.idea

--- a/src/commands/php-errors.php
+++ b/src/commands/php-errors.php
@@ -147,20 +147,6 @@ class Get_PHP_Errors extends Command {
             exit;
         }
 
-        $output->writeln( "<comment>Getting bot collaborator SFTP credentials.</comment>" );
-
-        $output->writeln( "<comment>Removing bot collaborator.</comment>" );
-
-        $delete_contributor_request = $api_helper->call_pressable_api(
-            "sites/{$pressable_site->id}/collaborators/{$collaborator_id}",
-            'DELETE',
-            array()
-        );
-
-        if ( is_null( $collaborator_id ) ) {
-            $output->writeln( "<error>Unable to remove temporary bot collaborator. Please remove manually.</error>" );
-        }
-
         // If they asked for the raw log, give it to them and bail.
         if ( ! empty( $input->getOption( 'raw' ) ) ) {
             passthru( 'clear' );


### PR DESCRIPTION
### Changes proposed in the PR
This PR makes changes suggested in issue [1167](https://github.com/a8cteam51/team51-dev-requests/issues/1167).
The order of execution is now `Get User SFTP credentials -> Get Errors` or `Get User SFTP credentials(fail) -> Add User -> Get User SFTP credentials -> Get Errors`. This made the command a lot faster (after the bot user is added to the site, so only the first execution is slower). Also, the delete function is removed because the bot user doesn't need to be removed.
I also made some code improvements and moved blocks of logic to functions so the code is cleaner, we can do more improvements in this regard (didn't want to bloat the PR)

### Testing instructions
Execute the command `team51 php-errors %site_name%`.
If a bot collaborator is already added then the first Get User SFTP credentials command will return results. Try deleting the collaborator by using the API endpoint `https://my.pressable.com/v1/sites/%site_id%/collaborators/%collaborator_id%` and executing the command again to see the adding of the user.