### PR TITLE
Pressable Add Collaborator: update roles of added collaborator

### DIFF
--- a/src/commands/pressable-grant-access.php
+++ b/src/commands/pressable-grant-access.php
@@ -334,7 +334,7 @@ class Pressable_Grant_Access extends Command {
 				array(
 					'email'   => $email,
 					'siteIds' => array( $site_id ),
-					'roles'   => array( 'clone_site', 'sftp_access', 'download_backups', 'reset_collaborator_password', 'wp_access' ),
+					'roles'   => array( 'clone_site', 'sftp_access', 'download_backups', 'reset_collaborator_password', 'manage_performance' ),
 				)
 			);
 


### PR DESCRIPTION
Removed `wp_access` role and add `manage_performance` role

Issue: https://github.com/Automattic/team51-cli/issues/95
