### PR TITLE
Add command to call Pressable API

### DIFF
--- a/load-application.php
+++ b/load-application.php
@@ -31,6 +31,7 @@ $application->add( new Team51\Command\Update_Repository_Secret() );
 $application->add( new Team51\Command\Plugin_List() );
 $application->add( new Team51\Command\Pressable_Generate_Token() );
 $application->add( new Team51\Command\Pressable_Grant_Access() );
+$application->add( new Team51\Command\Pressable_Call_Api() );
 
 
 $application->run();

--- a/src/commands/pressable-call-api.php
+++ b/src/commands/pressable-call-api.php
@@ -97,6 +97,12 @@ class Pressable_Call_Api extends Command {
 			$method = 'GET';
 		}
 
+		// Make sure it's a valid http method.
+		if ( ! in_array( $method, array( 'GET', 'POST', 'PUT', 'DELETE' ), true ) ) {
+			$output->writeln( '<error>You must supply a valid HTTP method.</error>' );
+			exit;
+		}
+
 		return $method;
 	}
 

--- a/src/commands/pressable-call-api.php
+++ b/src/commands/pressable-call-api.php
@@ -109,11 +109,6 @@ class Pressable_Call_Api extends Command {
 		// Attempt to get data from Input.
 		$data = $input->getOption( 'data' );
 
-		// If we don't have data, prompt the user.
-		if ( empty( $data ) ) {
-			$data = $this->get_question_helper()->ask( $input, $output, $this->ask_data() );
-		}
-
 		// If this isn't valid JSON data, fail.
 		if ( ! empty( $data ) && null === json_decode( $data ) ) {
 			$output->writeln( '<error>You must supply a valid JSON encoded string.</error>' );

--- a/src/commands/pressable-call-api.php
+++ b/src/commands/pressable-call-api.php
@@ -76,6 +76,8 @@ class Pressable_Call_Api extends Command {
 			exit;
 		}
 
+		// Account for leading slashes, if provided.
+		$query = trim( $query, '/' );
 		return $query;
 	}
 

--- a/src/commands/pressable-call-api.php
+++ b/src/commands/pressable-call-api.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Team51\Command;
+
+use stdClass;
+use Team51\Helper\API_Helper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class Pressable_Call_Api extends Command {
+	protected static $defaultName = 'pressable-call-api';
+	private $api_helper;
+	private $output;
+
+	/** @inheritDoc */
+	protected function configure() {
+		$this
+		->setDescription( 'Calls the Pressable API directly' )
+		->setHelp( 'Refer to the API docs for more details: https://my.pressable.com/documentation/api/v1' )
+		->addOption( 'query', null, InputOption::VALUE_REQUIRED, 'The query string for the request. This is everything after "https://my.pressable.com/v1/" in URL. (e.g., "sites/1234"' )
+		->addOption( 'method', null, InputOption::VALUE_OPTIONAL, 'The query type (GET, POST, etc.). Default is GET.' )
+		->addOption( 'data', null, InputOption::VALUE_OPTIONAL, 'A JSON string of the data to pass on. (e.g.: {"paginate":true}' );
+	}
+
+	/**
+	 * Access to the QuestionHelper
+	 *
+	 * @return \Symfony\Component\Console\Helper\QuestionHelper
+	 */
+	private function get_question_helper(): QuestionHelper {
+		return $this->getHelper( 'question' );
+	}
+
+
+	/**
+	 * Main callback for the command.
+	 *
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return void
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$this->api_helper = new API_Helper();
+		$this->output     = $output;
+
+		$this->handle_api_call( $input, $output );
+
+		$output->writeln( "<info>\nAll done!<info>" );
+	}
+
+	/***********************************
+	 ***********************************
+	 *          INPUT GETTERS          *
+	 ***********************************
+	 ***********************************/
+
+	/**
+	 * Gets the query string.
+	 *
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return string
+	 */
+	private function get_query( InputInterface $input, OutputInterface $output ): string {
+		// Attempt to get the query from the Input.
+		$query = $input->getOption( 'query' );
+
+		// If not provided, fail
+		if ( empty( $query ) ) {
+			$output->writeln( '<error>You must supply a valid query string.</error>' );
+			exit;
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Gets the query method, defaulting to GET.
+	 *
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return string
+	 */
+	private function get_method( InputInterface $input, OutputInterface $output ): string {
+		// Attempt to get search term from Input.
+		$method = $input->getOption( 'method' );
+
+		// If we don't have a method, default to GET.
+		if ( empty( $method ) ) {
+			$method = 'GET';
+		}
+
+		return $method;
+	}
+
+	/**
+	 * Gets the query data from Input or prompted for.
+	 *
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return string
+	 */
+	private function get_data( InputInterface $input, OutputInterface $output ): string {
+		// Attempt to get data from Input.
+		$data = $input->getOption( 'data' );
+
+		// If we don't have data, prompt the user.
+		if ( empty( $data ) ) {
+			$data = $this->get_question_helper()->ask( $input, $output, $this->ask_data() );
+		}
+
+		// If this isn't valid JSON data, fail.
+		if ( ! empty( $data ) && null === json_decode( $data ) ) {
+			$output->writeln( '<error>You must supply a valid JSON encoded string.</error>' );
+			exit;
+		}
+
+		return $data;
+	}
+
+	/*************************************
+	 *************************************
+	 *             QUESTIONS             *
+	 *************************************
+	 *************************************/
+
+
+	/**
+	 * Returns the question for getting JSON data.
+	 *
+	 * @return \Symfony\Component\Console\Question\Question
+	 */
+	private function ask_data(): Question {
+		return new Question( 'Please enter the JSON data to pass to the API: ', false );
+	}
+
+	/*************************************
+	 *************************************
+	 *             HANDLERS              *
+	 *************************************
+	 *************************************/
+
+	/**
+	 * Handles the call to the Pressable API.
+	 *
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @return void
+	 */
+	private function handle_api_call( InputInterface $input, OutputInterface $output ): void {
+		// Get the query data.
+		$query = $this->get_query( $input, $output );
+
+		$method = $this->get_method( $input, $output );
+
+		$data = $this->get_data( $input, $output );
+
+		// Callback for API call
+		$output->writeln( sprintf( '<info>Attempting to call Pressable API at endpoint %s using %s. Data: %s</info>', $query, $method, $data ) );
+
+		$result = $this->api_helper->call_pressable_api( $query, $method, $data );
+
+		$output->writeln( sprintf( '<info>API call result: %s</info>', print_r( $result, true ) ) );
+	}
+
+}

--- a/src/commands/pressable-call-api.php
+++ b/src/commands/pressable-call-api.php
@@ -109,31 +109,14 @@ class Pressable_Call_Api extends Command {
 	 */
 	private function get_data( InputInterface $input, OutputInterface $output ): string {
 		// Attempt to get data from Input.
-		$data = $input->getOption( 'data' );
+		$data = $input->getOption( 'data' ) ?? '';
 
 		// If this isn't valid JSON data, fail.
 		if ( ! empty( $data ) && null === json_decode( $data ) ) {
 			$output->writeln( '<error>You must supply a valid JSON encoded string.</error>' );
 			exit;
 		}
-
 		return $data;
-	}
-
-	/*************************************
-	 *************************************
-	 *             QUESTIONS             *
-	 *************************************
-	 *************************************/
-
-
-	/**
-	 * Returns the question for getting JSON data.
-	 *
-	 * @return \Symfony\Component\Console\Question\Question
-	 */
-	private function ask_data(): Question {
-		return new Question( 'Please enter the JSON data to pass to the API: ', false );
 	}
 
 	/*************************************
@@ -158,7 +141,7 @@ class Pressable_Call_Api extends Command {
 		$data = $this->get_data( $input, $output );
 
 		// Callback for API call
-		$output->writeln( sprintf( '<info>Attempting to call Pressable API at endpoint %s using %s. Data: %s</info>', $query, $method, $data ) );
+		$output->writeln( sprintf( "<info>Attempting to call Pressable API at endpoint %s using %s. \nData:\n%s</info>", $query, $method, $data ) );
 
 		$result = $this->api_helper->call_pressable_api( $query, $method, $data );
 


### PR DESCRIPTION
This adds the `pressable-call-api` command, which will call the [Pressable API](https://my.pressable.com/documentation/api/v1) directly with the information passed. It doesn't validate the correctness of the API call, as that will be left up to the API.

## Usage

`team51 pressable-call-api --query=<query_string> [--method=<GET|POST|PUT|DELETE] [--data=<JSON string>]`

If `--data` isn't provided, the user will be prompted. Hit enter to send an empty data object.

`--query` should be everything after `https://my.pressable.com/v1` (e.g., if you are getting the site list, you would pass `--query=sites` (`/sites` is also acceptable)

`--method` is the query method (`GET` (default), `POST`, `PUT`, `DELETE`)

`--data` is a JSON-formatted string to send as data with the request.

For example, to send [this example Update Site request](https://my.pressable.com/documentation/api/v1#update-site):

```
curl --location --request PUT 'https://my.pressable.com/v1/sites/500' \
--header 'Authorization: Bearer cjh02WI6u4j4QpKZeKFCAGF9uLINWTXlj9y8Dn' \
--header 'Content-Type: application/json' \
--data-raw '{
  "name": "Five Hundred Site",
  "php_version": "8.0"
}'
```

You would enter: `team51 pressable-call-api --query=sites/500 --method=PUT --data='{"name":"Five Hundred Site","php_version":"8.0"}'`

Built while working on #100 
