### PR TITLE
Increase timeout for concurrent calls from 10s to 60s

### DIFF
--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -351,6 +351,8 @@ class API_Helper {
 			$promises[ $endpoint ] = call(
 				static function () use ( $method, $client, $endpoint ) {
 					$request = new Request( $endpoint, $method );
+					$request->setInactivityTimeout( 60000 );
+					$request->setTransferTimeout( 60000 );
 					$request->setHeader( 'Accept', 'application/json' );
 					$request->setHeader( 'Content-Type', 'application/json' );
 					$request->setHeader( 'Authorization', 'Bearer ' . WPCOM_API_ACCOUNT_TOKEN );


### PR DESCRIPTION
Fixes timeout issues with the `remove-user` command. See [Slack thread](https://a8c.slack.com/archives/C018UMRUN3V/p1662747448325709).