### PR TITLE
Retrieve only the last X lines from the error log 

### DIFF
--- a/src/commands/pressable-site-php-errors.php
+++ b/src/commands/pressable-site-php-errors.php
@@ -82,7 +82,7 @@ class Pressable_Site_PHP_Errors extends Command {
 		// Retrieve and validate the modifier options.
 		$this->format = get_enum_input( $input, $output, 'format', array( 'raw', 'table' ) );
 		$this->limit  = max( 1, (int) $input->getOption( 'limit' ) );
-		$this->lines  = max( 1, (int) $input->getOption( 'lines' ) );
+		$this->lines  = max( $this->limit, (int) $input->getOption( 'lines' ) );
 
 		// Retrieve and validate the site.
 		$this->pressable_site = get_pressable_site_from_input( $input, $output, fn() => $this->prompt_site_input( $input, $output ) );


### PR DESCRIPTION
Last night we had an issue where a log file was 2.7 GB in size and the `php-errors` command could not parse it (the CLI ran out of RAM, naturally). By running `wc -l` on said file, it contains almost 145 **million** lines of PHP warnings, notices, and errors.

This PR changes the behavior of the `php-errors` command by making it pull the last 100k lines instead of the whole file. Assuming an average line size of 200 characters, that's about 2 MB of RAM only. The assumption is that the last few errors we're looking for are inside those last 100k lines.

This can be adjusted by using the `--lines` option. Most likely needed if using the `--format raw` option to bring that number down to 50-100 or so. 