### PR TITLE
Wait until site exists the cloning state

### DIFF
--- a/src/commands/create-development-site.php
+++ b/src/commands/create-development-site.php
@@ -364,7 +364,7 @@ class Create_Development_Site extends Command {
 			}
 
 			$progress_bar->advance();
-			sleep( 1 );
+			sleep( 'deploying' === $state ? 1 : 10 );
 		} while ( $state === $pressable_site->state );
 
 		$progress_bar->finish();
@@ -388,7 +388,7 @@ class Create_Development_Site extends Command {
 			$progress_bar = new ProgressBar( $output );
 			$progress_bar->start();
 
-			for ( $try = 0, $delay = 10; $try <= 12; $try++ ) {
+			for ( $try = 0, $delay = 5; $try <= 24; $try++ ) {
 				$ssh_connection = Pressable_Connection_Helper::get_ssh_connection( $site_id );
 				if ( ! \is_null( $ssh_connection ) ) {
 					break;

--- a/src/commands/create-development-site.php
+++ b/src/commands/create-development-site.php
@@ -13,6 +13,7 @@ use Team51\Helper\Pressable_Connection_Helper;
 use function Team51\Helper\get_pressable_site_by_id;
 use function Team51\Helper\get_pressable_site_sftp_user_by_email;
 use function Team51\Helper\run_app_command;
+use function Team51\Helper\run_pressable_site_wp_cli_command;
 
 class Create_Development_Site extends Command {
 	protected static $defaultName = 'create-development-site';
@@ -117,26 +118,20 @@ class Create_Development_Site extends Command {
 			$output->writeln( '<error>Failed to connect to the Pressable site via SSH. Safety Net not installed.</error>' );
 		}
 
-		run_app_command(
+		run_pressable_site_wp_cli_command(
 			$this->getApplication(),
-			Pressable_Site_Run_WP_CLI_Command::getDefaultName(),
-			array(
-				'site'           => $pressable_site->data->id,
-				'wp-cli-command' => 'config set WP_ENVIRONMENT_TYPE staging --type=constant',
-			),
+			$pressable_site->data->id,
+			'config set WP_ENVIRONMENT_TYPE staging --type=constant',
 			$output
 		);
 
 		if ( ! empty( $input->getOption( 'skip-safety-net' ) ) ) {
 			$output->writeln( '<comment>Skipping Safety Net installation.</comment>' );
 		} else {
-			run_app_command(
+			run_pressable_site_wp_cli_command(
 				$this->getApplication(),
-				Pressable_Site_Run_WP_CLI_Command::getDefaultName(),
-				array(
-					'site'           => $pressable_site->data->id,
-					'wp-cli-command' => 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip',
-				),
+				$pressable_site->data->id,
+				'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip',
 				$output
 			);
 

--- a/src/helpers/pressable-functions.php
+++ b/src/helpers/pressable-functions.php
@@ -549,9 +549,10 @@ function set_pressable_site_primary_domain( string $site_id, string $domain_id )
  * @param   bool                $interactive        Whether to run the command in interactive mode.
  *
  * @return int  The command exit code.
- * @throws ExceptionInterface   If the command does not exist or if the input is invalid.
+ * @noinspection PhpDocMissingThrowsInspection
  */
 function run_pressable_site_wp_cli_command( Application $application, string $site_id_or_url, string $wp_cli_command, OutputInterface $output, bool $interactive = false ): int {
+	/* @noinspection PhpUnhandledExceptionInspection */
 	return run_app_command(
 		$application,
 		Pressable_Site_Run_WP_CLI_Command::getDefaultName(),


### PR DESCRIPTION
Installing SafetyNet on newly cloned sites required us to wait until the site finished cloning and SSH has been provisioned. The site cloning can take anywhere between 10-20 seconds and 5-10 minutes. 

The `create-development-site` command already waited until the site passed the `deploying` state. Now it will also wait until the site passes the `cloning` state.

This should ensure that SSH connections can always be established and SafetyNet can be installed