### PR TITLE
Feat/183 plugin search speedup

### DIFF
--- a/src/commands/plugin-search.php
+++ b/src/commands/plugin-search.php
@@ -2,7 +2,6 @@
 
 namespace Team51\Command;
 
-use Team51\Helper\API_Helper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,52 +9,90 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Team51\Helper\WPCOM_API_Helper;
+use function Team51\Helper\get_wpcom_jetpack_sites;
+use function Team51\Helper\get_wpcom_sites;
+use function Team51\Helper\maybe_define_console_verbosity;
 
 
 class Plugin_Search extends Command {
-	protected static $defaultName = 'plugin-search';
+	// region FIELDS AND CONSTANTS
 
 	/**
-	 * @var Api_Helper|null API Helper instance.
+	 * {@inheritdoc}
 	 */
-	protected $api_helper = null;
+	protected static $defaultName = 'plugin-search'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 
-	public function __construct() {
-		parent::__construct();
+	/**
+	 * The plugin slug to search for.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $plugin_slug = null;
 
-		$this->api_helper = new API_Helper();
+	/**
+	 * Whether to do a partial search.
+	 *
+	 * @var bool|null
+	 */
+	protected ?bool $partial = null;
+
+	//endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( "Search all Team 51 sites for a specific plugin." )
+			->setHelp( "This command will output a list of sites where a particular plugin is installed. A Jetpack site connected to the a8cteam51 account.\nThe search can be made for an exact match plugin slug, or\na general text search. Letter case is ignored in both search types.\nExample usage:\nplugin-search woocommerce\nplugin-search woo --partial='true'\n" );
+
+		$this->addArgument( 'plugin-slug', InputArgument::REQUIRED, "The slug of the plugin to search for. This is an exact match against the plugin installation folder name,\nthe main plugin file name without the .php extension, and the Text Domain.\n" )
+			->addOption( 'partial', null, InputOption::VALUE_OPTIONAL, "Optional.\nUse for general text/partial match search. Using this option will also search the plugin Name field." );
 	}
 
-	protected function configure() {
-		$this
-		->setDescription( "Search all Team 51 sites for a specific plugin." )
-		->setHelp( "This command will output a list of sites where a particular plugin is installed. A Jetpack site connected to the a8cteam51 account.\nThe search can be made for an exact match plugin slug, or\na general text search. Letter case is ignored in both search types.\nExample usage:\nplugin-search woocommerce\nplugin-search woo --partial='true'\n" )
-		->addArgument( 'plugin-slug', InputArgument::REQUIRED, "The slug of the plugin to search for. This is an exact match against the plugin installation folder name,\nthe main plugin file name without the .php extension, and the Text Domain.\n" )
-		->addOption( 'partial', null, InputOption::VALUE_OPTIONAL, "Optional.\nUse for general text/partial match search. Using this option will also search the plugin Name field." );
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		maybe_define_console_verbosity( $output->getVerbosity() );
+
+		$this->plugin_slug = strtolower( $input->getArgument( 'plugin-slug' ) );
+		$this->partial     = (bool) $input->getOption( 'partial' );
 	}
 
-	protected function execute( InputInterface $input, OutputInterface $output ) {
-		$plugin_slug = strtolower( $input->getArgument( 'plugin-slug' ) );
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$plugins = WPCOM_API_Helper::call_api( '/me/sites/plugins' );
+		var_dump( count( (array) $plugins->sites ) );
 
-		$api_helper = new API_Helper;
+		$sites = get_wpcom_jetpack_sites();
+		var_dump( count( $sites ) );
+
+		$sites = get_wpcom_sites();
+		var_dump( count( $sites ) );
+
+		return 0;
 
 		$output->writeln( '<info>Fetching list of sites...<info>' );
 
-		$sites = $api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/', array() );
-
+		$sites = get_wpcom_jetpack_sites();
 		if ( empty( $sites ) ) {
 			$output->writeln( '<error>Failed to fetch sites.<error>' );
-			exit;
+			return 1;
 		}
 
 		$site_list = array();
-		foreach ( $sites->blogs->blogs as $site ) {
+		foreach ( $sites as $site ) {
 			$site_list[] = array( $site->userblog_id, $site->domain );
 		}
 		$site_count = count( $site_list );
 
 		$output->writeln( "<info>{$site_count} sites found.<info>" );
-		$output->writeln( "<info>Checking each site for the plugin slug: {$plugin_slug}<info>" );
+		$output->writeln( "<info>Checking each site for the plugin slug: {$this->plugin_slug}<info>" );
 
 		$progress_bar = new ProgressBar( $output, $site_count );
 		$progress_bar->start();
@@ -71,12 +108,12 @@ class Plugin_Search extends Command {
 					foreach ( $plugins_array as $plugin_path => $plugin ) {
 						$folder_name = strstr( $plugin_path, '/', true );
 						$file_name   = str_replace( array( '/', '.php' ), '', strrchr( $plugin_path, '/' ) );
-						if ( $input->getOption( 'partial' ) ) {
-							if ( false !== strpos( $plugin['TextDomain'], $plugin_slug ) || false !== strpos( $folder_name, $plugin_slug ) || false !== strpos( $file_name, $plugin_slug ) || false !== strpos( strtolower( $plugin['Name'] ), $plugin_slug ) ) {
+						if ( $this->partial ) {
+							if ( false !== strpos( $plugin['TextDomain'], $this->plugin_slug ) || false !== strpos( $folder_name, $this->plugin_slug ) || false !== strpos( $file_name, $this->plugin_slug ) || false !== strpos( strtolower( $plugin['Name'] ), $this->plugin_slug ) ) {
 								$sites_with_plugin[] = array( $site[1], $plugin['Name'], ( $plugin['active'] ? 'Active' : 'Inactive' ), $plugin['Version'] );
 							}
 						} else {
-							if ( $plugin_slug === $plugin['TextDomain'] || $plugin_slug === $folder_name || $plugin_slug === $file_name ) {
+							if ( $this->plugin_slug === $plugin['TextDomain'] || $this->plugin_slug === $folder_name || $this->plugin_slug === $file_name ) {
 								$sites_with_plugin[] = array( $site[1], $plugin['Name'], ( $plugin['active'] ? 'Active' : 'Inactive' ), $plugin['Version'] );
 							}
 						}
@@ -103,8 +140,10 @@ class Plugin_Search extends Command {
 		$not_found_table->render();
 
 		$output->writeln( '<info>All done! :)<info>' );
-
+		return 0;
 	}
+
+	// endregion
 
 	private function get_list_of_plugins( $site_id ) {
 		$plugin_list = $this->api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site_id . '/rest-api/?path=/jetpack/v4/plugins', array() );

--- a/src/commands/plugin-search.php
+++ b/src/commands/plugin-search.php
@@ -8,13 +8,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Team51\Helper\WPCOM_API_Helper;
+use function Team51\Helper\decode_json_content;
+use function Team51\Helper\encode_json_content;
 use function Team51\Helper\get_wpcom_jetpack_sites;
-use function Team51\Helper\get_wpcom_sites;
 use function Team51\Helper\maybe_define_console_verbosity;
 
-
+/**
+ * CLI command to search all Team51 sites for a specific plugin.
+ */
 class Plugin_Search extends Command {
 	// region FIELDS AND CONSTANTS
 
@@ -45,11 +47,11 @@ class Plugin_Search extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( "Search all Team 51 sites for a specific plugin." )
-			->setHelp( "This command will output a list of sites where a particular plugin is installed. A Jetpack site connected to the a8cteam51 account.\nThe search can be made for an exact match plugin slug, or\na general text search. Letter case is ignored in both search types.\nExample usage:\nplugin-search woocommerce\nplugin-search woo --partial='true'\n" );
+		$this->setDescription( 'Search all Team51 WPCOM Jetpack sites for a specific plugin.' )
+			->setHelp( "This command will output a list of Jetpack sites connected to the a8cteam51 account where a particular plugin is installed.\nThe search can be made for an exact match plugin slug, or\na general text search. Letter case is ignored in both search types.\nExample usage:\nplugin-search woocommerce\nplugin-search woo --partial\n" );
 
 		$this->addArgument( 'plugin-slug', InputArgument::REQUIRED, "The slug of the plugin to search for. This is an exact match against the plugin installation folder name,\nthe main plugin file name without the .php extension, and the Text Domain.\n" )
-			->addOption( 'partial', null, InputOption::VALUE_OPTIONAL, "Optional.\nUse for general text/partial match search. Using this option will also search the plugin Name field." );
+			->addOption( 'partial', null, InputOption::VALUE_NONE, "Optional.\nUse for general text/partial match search. Using this option will also search the plugin Name field." );
 	}
 
 	/**
@@ -58,7 +60,7 @@ class Plugin_Search extends Command {
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		maybe_define_console_verbosity( $output->getVerbosity() );
 
-		$this->plugin_slug = strtolower( $input->getArgument( 'plugin-slug' ) );
+		$this->plugin_slug = \strtolower( $input->getArgument( 'plugin-slug' ) );
 		$this->partial     = (bool) $input->getOption( 'partial' );
 	}
 
@@ -66,91 +68,140 @@ class Plugin_Search extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$plugins = WPCOM_API_Helper::call_api( '/me/sites/plugins' );
-		var_dump( count( (array) $plugins->sites ) );
+		$partial_match_text = $this->partial ? 'partial' : 'exact';
+		$output->writeln( "<fg=magenta;options=bold>Searching through the WPCOM Jetpack sites for the plugin with the slug `$this->plugin_slug` ($partial_match_text match).</>" );
 
-		$sites = get_wpcom_jetpack_sites();
-		var_dump( count( $sites ) );
-
-		$sites = get_wpcom_sites();
-		var_dump( count( $sites ) );
-
-		return 0;
-
-		$output->writeln( '<info>Fetching list of sites...<info>' );
-
+		// Get the list of sites.
 		$sites = get_wpcom_jetpack_sites();
 		if ( empty( $sites ) ) {
 			$output->writeln( '<error>Failed to fetch sites.<error>' );
 			return 1;
 		}
 
-		$site_list = array();
-		foreach ( $sites as $site ) {
-			$site_list[] = array( $site->userblog_id, $site->domain );
-		}
-		$site_count = count( $site_list );
+		$output->writeln( '<fg=green;options=bold>Successfully fetched ' . count( $sites ) . ' Jetpack sites.</>', OutputInterface::VERBOSITY_VERBOSE );
 
-		$output->writeln( "<info>{$site_count} sites found.<info>" );
-		$output->writeln( "<info>Checking each site for the plugin slug: {$this->plugin_slug}<info>" );
+		// Get the list of plugins for each site.
+		$sites_plugins = WPCOM_API_Helper::call_api_concurrent(
+			\array_map(
+				static fn( $site ) => "/jetpack-blogs/$site->userblog_id/rest-api/?path=/jetpack/v4/plugins",
+				$sites
+			)
+		);
+		$sites_plugins = \array_combine(
+			\array_column( $sites, 'userblog_id' ),
+			$sites_plugins
+		);
 
-		$progress_bar = new ProgressBar( $output, $site_count );
-		$progress_bar->start();
-
+		// Filter the sites that have the plugin installed.
 		$sites_with_plugin = array();
 		$sites_not_checked = array();
-		foreach ( $site_list as $site ) {
-			$progress_bar->advance();
-			$plugin_list = $this->get_list_of_plugins( $site[0] );
-			if ( ! is_null( $plugin_list ) ) {
-				if ( ! is_null( $plugin_list->data ) ) {
-					$plugins_array = json_decode( json_encode( $plugin_list->data ), true );
-					foreach ( $plugins_array as $plugin_path => $plugin ) {
-						$folder_name = strstr( $plugin_path, '/', true );
-						$file_name   = str_replace( array( '/', '.php' ), '', strrchr( $plugin_path, '/' ) );
-						if ( $this->partial ) {
-							if ( false !== strpos( $plugin['TextDomain'], $this->plugin_slug ) || false !== strpos( $folder_name, $this->plugin_slug ) || false !== strpos( $file_name, $this->plugin_slug ) || false !== strpos( strtolower( $plugin['Name'] ), $this->plugin_slug ) ) {
-								$sites_with_plugin[] = array( $site[1], $plugin['Name'], ( $plugin['active'] ? 'Active' : 'Inactive' ), $plugin['Version'] );
-							}
-						} else {
-							if ( $this->plugin_slug === $plugin['TextDomain'] || $this->plugin_slug === $folder_name || $this->plugin_slug === $file_name ) {
-								$sites_with_plugin[] = array( $site[1], $plugin['Name'], ( $plugin['active'] ? 'Active' : 'Inactive' ), $plugin['Version'] );
-							}
-						}
-					}
+		foreach ( $sites_plugins as $jetpack_id => $plugins_list ) {
+			if ( \is_null( $plugins_list ) || ! \property_exists( $plugins_list, 'data' ) ) {
+				$sites_not_checked[ $jetpack_id ] = $sites[ $jetpack_id ];
+				continue;
+			}
+
+			$plugins_array = decode_json_content( encode_json_content( $plugins_list->data ), true );
+			foreach ( $plugins_array as $plugin_path => $plugin_data ) {
+				$plugin_folder = \strstr( $plugin_path, '/', true );
+				$plugin_file   = \basename( $plugin_path, '.php' );
+
+				if ( $this->is_exact_match( $plugin_data, $plugin_folder, $plugin_file ) || ( $this->partial && $this->is_partial_match( $plugin_data, $plugin_folder, $plugin_file ) ) ) {
+					$sites_with_plugin[ $jetpack_id ]['site']      = $sites[ $jetpack_id ];
+					$sites_with_plugin[ $jetpack_id ]['plugins'][] = $plugin_data + array( 'path' => $plugin_path );
 				}
-			} else {
-				$sites_not_checked[] = array( $site[1], $site[0] );
 			}
 		}
-		$progress_bar->finish();
-		$output->writeln( '<info>  Yay!</info>' );
 
-		$site_table = new Table( $output );
-		$site_table->setStyle( 'box-double' );
-		$site_table->setHeaders( array( 'Site URL', 'Plugin Name', 'Plugin Status', 'Plugin Version' ) );
-		$site_table->setRows( $sites_with_plugin );
-		$site_table->render();
+		// Output the results.
+		$output->writeln( '<fg=green;options=bold>Found ' . count( $sites_with_plugin ) . ' sites with the plugin installed.</>', OutputInterface::VERBOSITY_VERBOSE );
+		$this->output_found_site_list( $sites_with_plugin, $output );
 
-		$output->writeln( '<info>Ignored sites - either not a Jetpack connected site, or the connection is broken.<info>' );
-		$not_found_table = new Table( $output );
-		$not_found_table->setStyle( 'box-double' );
-		$not_found_table->setHeaders( array( 'Site URL', 'Site ID' ) );
-		$not_found_table->setRows( $sites_not_checked );
-		$not_found_table->render();
+		if ( ! empty( $sites_not_checked ) ) {
+			$output->writeln( '<fg=yellow;options=bold>Could not check ' . count( $sites_not_checked ) . ' sites for the plugin.</>', OutputInterface::VERBOSITY_VERBOSE );
+			$this->output_not_checked_site_list( $sites_not_checked, $output );
+		}
 
-		$output->writeln( '<info>All done! :)<info>' );
 		return 0;
 	}
 
 	// endregion
 
-	private function get_list_of_plugins( $site_id ) {
-		$plugin_list = $this->api_helper->call_wpcom_api( 'rest/v1.1/jetpack-blogs/' . $site_id . '/rest-api/?path=/jetpack/v4/plugins', array() );
-		if ( ! empty( $plugin_list->error ) ) {
-			$plugin_list = null;
-		}
-		return $plugin_list;
+	// region HELPERS
+
+	/**
+	 * Returns whether the given plugin data is an exact match for the plugin slug.
+	 *
+	 * @param   array   $plugin_data        The plugin data as returned by the API.
+	 * @param   string  $plugin_folder      The plugin folder name.
+	 * @param   string  $plugin_file        The plugin file name.
+	 *
+	 * @return  bool
+	 */
+	protected function is_exact_match( array $plugin_data, string $plugin_folder, string $plugin_file ): bool {
+		return $this->plugin_slug === $plugin_data['TextDomain'] || $this->plugin_slug === $plugin_folder || $this->plugin_slug === $plugin_file;
 	}
 
+	/**
+	 * Returns whether the given plugin data is a partial match for the plugin slug.
+	 *
+	 * @param   array   $plugin_data        The plugin data as returned by the API.
+	 * @param   string  $plugin_folder      The plugin folder name.
+	 * @param   string  $plugin_file        The plugin file name.
+	 *
+	 * @return  bool
+	 */
+	protected function is_partial_match( array $plugin_data, string $plugin_folder, string $plugin_file ): bool {
+		return false !== strpos( $plugin_data['TextDomain'], $this->plugin_slug ) || false !== strpos( $plugin_folder, $this->plugin_slug ) || false !== strpos( $plugin_file, $this->plugin_slug ) || false !== stripos( $plugin_data['Name'], $this->plugin_slug );
+	}
+
+	/**
+	 * Outputs in tabular form the list of sites that have the plugin installed.
+	 *
+	 * @param   array               $sites_with_plugin      The list of sites with the plugin installed.
+	 * @param   OutputInterface     $output                 The output object.
+	 *
+	 * @return  void
+	 */
+	protected function output_found_site_list( array $sites_with_plugin, OutputInterface $output ): void {
+		$table = new Table( $output );
+
+		$table->setHeaderTitle( 'Found sites' );
+		$table->setHeaders( array( 'Site URL', 'Plugin Name', 'Plugin Path', 'Plugin Status', 'Plugin Version' ) );
+
+		foreach ( $sites_with_plugin as $site ) {
+			foreach ( $site['plugins'] as $match ) {
+				$table->addRow( array( $site['site']->domain, $match['Name'], $match['path'], ( $match['active'] ? 'Active' : 'Inactive' ), $match['Version'] ) );
+			}
+		}
+
+		$table->setColumnMaxWidth( 0, 128 );
+		$table->setStyle( 'box-double' );
+		$table->render();
+	}
+
+	/**
+	 * Outputs in tabular form the list of sites that could not be checked.
+	 *
+	 * @param   array               $sites_not_checked      The list of sites that could not be checked.
+	 * @param   OutputInterface     $output                 The output object.
+	 *
+	 * @return  void
+	 */
+	protected function output_not_checked_site_list( array $sites_not_checked, OutputInterface $output ): void {
+		$table = new Table( $output );
+
+		$table->setHeaderTitle( 'Sites not checked - most likely, the connection is broken' );
+		$table->setHeaders( array( 'Site URL', 'Site ID' ) );
+
+		foreach ( $sites_not_checked as $site ) {
+			$table->addRow( array( $site->domain, $site->userblog_id ) );
+		}
+
+		$table->setColumnMaxWidth( 0, 128 );
+		$table->setStyle( 'box-double' );
+		$table->render();
+	}
+
+	// endregion
 }

--- a/src/helpers/functions.php
+++ b/src/helpers/functions.php
@@ -192,7 +192,7 @@ function is_contractor_mode(): bool {
  */
 function is_quiet_mode(): bool {
 	return \in_array( '-q', $_SERVER['argv'], true )
-        || \in_array( '--quiet', $_SERVER['argv'], true );
+		|| \in_array( '--quiet', $_SERVER['argv'], true );
 }
 
 /**

--- a/src/helpers/wpcom-functions.php
+++ b/src/helpers/wpcom-functions.php
@@ -3,6 +3,30 @@
 namespace Team51\Helper;
 
 /**
+ * Gets the list of Jetpack sites connected to the a8cteam51 account.
+ *
+ * @return  object[]|null
+ */
+function get_wpcom_jetpack_sites(): ?array {
+	$sites = WPCOM_API_Helper::call_api( 'rest/v1.1/jetpack-blogs/' );
+	if ( is_null( $sites ) || ! property_exists( $sites, 'success' ) || ! $sites->success ) {
+		return null;
+	}
+
+	return $sites->blogs->blogs;
+}
+
+function get_wpcom_sites(): ?array {
+	$sites = WPCOM_API_Helper::call_api( 'rest/v1.1/me/sites/' );
+	if ( ! is_null( $sites ) && property_exists( $sites, 'error' ) ) {
+		console_writeln( $sites->message );
+		return null;
+	}
+
+	return $sites->sites;
+}
+
+/**
  * Gets the WordPress.com site information by site URL or WordPress.com ID (requires active Jetpack connection for WPORG sites).
  *
  * @param   string  $site_id_or_url     The site URL or WordPress.com site ID.


### PR DESCRIPTION
This PR refactors the `plugin-search` command by:

1. Simplifying the main body by moving chunks of code to helpers
2. Running the API calls in parallel instead of sequentially to speed up the results (±10 seconds vs 15 min previously)

See #183 