### PR TITLE
Dump body object on API error

### DIFF
--- a/src/helpers/wpcom-api-helper.php
+++ b/src/helpers/wpcom-api-helper.php
@@ -53,8 +53,9 @@ final class WPCOM_API_Helper {
 		);
 
 		if ( 0 !== \strpos( $result['headers']['http_code'], '2' ) ) {
+			$response_body = print_r($result['body'], true);
 			console_writeln(
-				"❌ WordPress.com API error ($endpoint): {$result['headers']['http_code']} {$result['body']}",
+				"❌ WordPress.com API error ($endpoint): {$result['headers']['http_code']} {$response_body}",
 				\in_array( $result['headers']['http_code'], array( 403, 404 ), true ) ? OutputInterface::VERBOSITY_DEBUG : OutputInterface::VERBOSITY_QUIET
 			);
 			return null;


### PR DESCRIPTION
Fixes error created when `$response['body']` is an object.

[Context](https://a8c.slack.com/archives/C018UMRUN3V/p1679689212811799?thread_ts=1679683757.618789&cid=C018UMRUN3V)