### PR TITLE
Better error handling/reporting

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -18,6 +18,9 @@
 
         <!-- Ignore WordPress-specific PHP recommendations. -->
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions"/>
-        <exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+    </rule>
+    <rule ref="Universal.Operators">
+        <!-- Allow short ternaries because they are just so useful. -->
+        <exclude name="Universal.Operators.DisallowShortTernary.Found"/>
     </rule>
 </ruleset>

--- a/src/commands/pressable-site-create-collaborator.php
+++ b/src/commands/pressable-site-create-collaborator.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use function Team51\Helper\create_pressable_site_collaborator;
 use function Team51\Helper\get_pressable_site_by_id;
 use function Team51\Helper\get_pressable_sites;
+use function Team51\Helper\maybe_define_console_verbosity;
 
 /**
  * CLI command for creating a new collaborator on a Pressable site.
@@ -34,6 +35,13 @@ class Pressable_Site_Create_Collaborator extends Command {
 		->addOption( 'email', null, InputOption::VALUE_REQUIRED, 'The user email.' )
 		->addOption( 'site', null, InputOption::VALUE_OPTIONAL, 'The Pressable site. Can be a numeric site ID or by domain.' )
 		->addOption( 'search', null, InputOption::VALUE_OPTIONAL, 'Search for any site by domain.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		maybe_define_console_verbosity( $output->getVerbosity() );
 	}
 
 	/**

--- a/src/commands/pressable-site-php-errors.php
+++ b/src/commands/pressable-site-php-errors.php
@@ -238,7 +238,7 @@ class Pressable_Site_PHP_Errors extends Command {
 		foreach ( $parsed_php_errors as $parsed_php_error ) {
 			$error_hash = \hash( 'md5', $parsed_php_error['error_message'] );
 			if ( isset( $stats_table[ $error_hash ] ) ) {
-				$stats_table[ $error_hash ]['error_count']++;
+				++$stats_table[ $error_hash ]['error_count'];
 
 				if ( \strtotime( $parsed_php_error['timestamp'] ) > \strtotime( $stats_table[ $error_hash ]['timestamp'] ) ) {
 					$stats_table[ $error_hash ]['timestamp'] = $parsed_php_error['timestamp'];

--- a/src/commands/pressable-upload-site-icon.php
+++ b/src/commands/pressable-upload-site-icon.php
@@ -53,7 +53,7 @@ final class Pressable_Site_Upload_Icon extends Command {
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		maybe_define_console_verbosity( $output->getVerbosity() );
 
-		$this->dry_run  = (bool) $input->getOption( 'dry-run' );
+		$this->dry_run = (bool) $input->getOption( 'dry-run' );
 
 		// Retrieve the given site.
 		$this->pressable_site = get_pressable_site_from_input( $input, $output, fn() => $this->prompt_site_input( $input, $output ) );
@@ -67,7 +67,7 @@ final class Pressable_Site_Upload_Icon extends Command {
 
 	/**
 	 * {@inheritDoc}
-     */
+	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$output->writeln( "<fg=green;options=bold>Uploading apple-touch-icon.png to {$this->pressable_site->url}</>" );
 

--- a/src/helpers/api-helpers.php
+++ b/src/helpers/api-helpers.php
@@ -16,7 +16,7 @@ class API_Helper {
 	private const PRESABLE_TOKEN_FILE         = TEAM51_CLI_ROOT_DIR . '/secrets/pressable_token.json';
 	private const PRESABLE_TOKEN_EXPIRE_AFTER = '-59 minutes';
 
-	public function call_pressable_api( $query, $method, $data = [] ) {
+	public function call_pressable_api( $query, $method, $data = array() ) {
 		$api_request_url = 'https://my.pressable.com/v1/' . $query;
 
 		$data = json_encode( $data );
@@ -317,7 +317,7 @@ class API_Helper {
 			),
 		);
 
-		$options['http']['content'] = json_encode( ['query' => $query ] );
+		$options['http']['content'] = json_encode( array( 'query' => $query ) );
 
 		$context = stream_context_create( $options );
 		$result  = @file_get_contents( $api_request_url, false, $context );

--- a/src/helpers/functions.php
+++ b/src/helpers/functions.php
@@ -88,6 +88,8 @@ function decode_json_content( string $json, bool $associative = false, int $flag
 		return \json_decode( $json, $associative, 512, $flags | JSON_THROW_ON_ERROR );
 	} catch ( \JsonException $exception ) {
 		console_writeln( "JSON Decoding Exception: {$exception->getMessage()}" );
+		console_writeln( 'Original JSON:' . \PHP_EOL . $json );
+		console_writeln( $exception->getTraceAsString() );
 		return null;
 	}
 }
@@ -105,6 +107,8 @@ function encode_json_content( $data, int $flags = 0 ): ?string {
 		return \json_encode( $data, $flags | JSON_THROW_ON_ERROR );
 	} catch ( \JsonException $exception ) {
 		console_writeln( "JSON Encoding Exception: {$exception->getMessage()}" );
+		console_writeln( 'Original data:' . \PHP_EOL . \print_r( $data, true ) );
+		console_writeln( $exception->getTraceAsString() );
 		return null;
 	}
 }

--- a/src/helpers/pressable-api-helper.php
+++ b/src/helpers/pressable-api-helper.php
@@ -58,14 +58,18 @@ final class Pressable_API_Helper {
 		}
 		if ( 0 !== \strpos( $result['headers']['http_code'], '2' ) ) {
 			$message = '';
-			if ( \property_exists( $result['body'], 'message' ) ) {
-				$message = $result['body']->message;
-			} elseif ( \property_exists( $result['body'], 'error' ) ) {
-				$message = $result['body']->error;
-			}
+			if ( \is_null( $result['body'] ) ) {
+				$message = '{no response body 😭}';
+			} else {
+				if ( \property_exists( $result['body'], 'message' ) ) {
+					$message = $result['body']->message;
+				} elseif ( \property_exists( $result['body'], 'error' ) ) {
+					$message = $result['body']->error;
+				}
 
-			if ( \property_exists( $result['body'], 'errors' ) && ! empty( $result['body']->errors ) ) {
-				$message .= ' ' . \implode( ', ', (array) $result['body']->errors );
+				if ( \property_exists( $result['body'], 'errors' ) && ! empty( $result['body']->errors ) ) {
+					$message .= ' ' . \implode( ', ', (array) $result['body']->errors );
+				}
 			}
 
 			console_writeln(

--- a/src/helpers/pressable-functions.php
+++ b/src/helpers/pressable-functions.php
@@ -327,7 +327,7 @@ function create_pressable_site_collaborator( string $collaborator_email, string 
 	}
 
 	// Now query the collaborator object. Adding the collaborator might take some time, so we need to retry it.
-	for ( $try = 0, $delay = 1; $try <= 3; $try++, $delay *= 2 ) {
+	for ( $try = 0, $delay = 1; $try <= 5; $try++, $delay *= 2 ) {
 		$collaborator = get_pressable_site_collaborator_by_email( $site_id, $collaborator_email );
 		if ( ! \is_null( $collaborator ) ) {
 			break;

--- a/src/helpers/pressable-functions.php
+++ b/src/helpers/pressable-functions.php
@@ -192,12 +192,13 @@ function get_pressable_site_sftp_user_by_username( string $site_id, string $user
  */
 function get_pressable_site_sftp_user_by_id( string $site_id, string $user_id ): ?object {
 	$sftp_users = get_pressable_site_sftp_users( $site_id );
+	if ( ! \is_array( $sftp_users ) ) {
+		return null;
+	}
 
-	if ( \is_array( $sftp_users ) ) {
-		foreach ( $sftp_users as $sftp_user ) {
-			if ( $user_id === (string) $sftp_user->id ) {
-				return $sftp_user;
-			}
+	foreach ( $sftp_users as $sftp_user ) {
+		if ( $user_id === (string) $sftp_user->id ) {
+			return $sftp_user;
 		}
 	}
 
@@ -214,12 +215,13 @@ function get_pressable_site_sftp_user_by_id( string $site_id, string $user_id ):
  */
 function get_pressable_site_sftp_user_by_email( string $site_id, string $user_email ): ?object {
 	$sftp_users = get_pressable_site_sftp_users( $site_id );
+	if ( ! \is_array( $sftp_users ) ) {
+		return null;
+	}
 
-	if ( \is_array( $sftp_users ) ) {
-		foreach ( $sftp_users as $sftp_user ) {
-			if ( ! empty( $sftp_user->email ) && true === is_case_insensitive_match( $sftp_user->email, $user_email ) ) {
-				return $sftp_user;
-			}
+	foreach ( $sftp_users as $sftp_user ) {
+		if ( ! empty( $sftp_user->email ) && true === is_case_insensitive_match( $sftp_user->email, $user_email ) ) {
+			return $sftp_user;
 		}
 	}
 

--- a/src/helpers/pressable-functions.php
+++ b/src/helpers/pressable-functions.php
@@ -3,7 +3,6 @@
 namespace Team51\Helper;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,7 +64,7 @@ function get_related_pressable_sites( object $site, ?callable $node_generator = 
 	$production_site = $site;
 	while ( ! empty( $production_site->clonedFromId ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$production_site = get_pressable_site_by_id( $production_site->clonedFromId ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		if ( false !== \is_null( $production_site ) ) {
+		if ( \is_null( $production_site ) ) {
 			break; // This is as high as we can go. Original site must've been deleted...
 		}
 	}
@@ -76,6 +75,9 @@ function get_related_pressable_sites( object $site, ?callable $node_generator = 
 
 	// Identify the related sites by level.
 	$all_sites = get_pressable_sites();
+	if ( ! \is_array( $all_sites ) ) {
+		return null;
+	}
 
 	do {
 		$has_next_level = false;
@@ -124,7 +126,7 @@ function get_pressable_site_by_id( string $site_id ): ?object {
  */
 function get_pressable_site_by_url( string $site_url, bool $exact = true ): ?object {
 	$sites = get_pressable_sites();
-	if ( \is_null( $sites ) ) {
+	if ( ! \is_array( $sites ) ) {
 		return null;
 	}
 
@@ -191,9 +193,11 @@ function get_pressable_site_sftp_user_by_username( string $site_id, string $user
 function get_pressable_site_sftp_user_by_id( string $site_id, string $user_id ): ?object {
 	$sftp_users = get_pressable_site_sftp_users( $site_id );
 
-	foreach ( $sftp_users as $sftp_user ) {
-		if ( $user_id === (string) $sftp_user->id ) {
-			return $sftp_user;
+	if ( \is_array( $sftp_users ) ) {
+		foreach ( $sftp_users as $sftp_user ) {
+			if ( $user_id === (string) $sftp_user->id ) {
+				return $sftp_user;
+			}
 		}
 	}
 
@@ -211,9 +215,11 @@ function get_pressable_site_sftp_user_by_id( string $site_id, string $user_id ):
 function get_pressable_site_sftp_user_by_email( string $site_id, string $user_email ): ?object {
 	$sftp_users = get_pressable_site_sftp_users( $site_id );
 
-	foreach ( $sftp_users as $sftp_user ) {
-		if ( ! empty( $sftp_user->email ) && true === is_case_insensitive_match( $sftp_user->email, $user_email ) ) {
-			return $sftp_user;
+	if ( \is_array( $sftp_users ) ) {
+		foreach ( $sftp_users as $sftp_user ) {
+			if ( ! empty( $sftp_user->email ) && true === is_case_insensitive_match( $sftp_user->email, $user_email ) ) {
+				return $sftp_user;
+			}
 		}
 	}
 
@@ -284,7 +290,7 @@ function get_pressable_site_collaborator_by_id( string $site_id, string $collabo
  */
 function get_pressable_site_collaborator_by_email( string $site_id, string $collaborator_email ): ?object {
 	$collaborators = get_pressable_site_collaborators( $site_id );
-	if ( \is_null( $collaborators ) ) {
+	if ( ! \is_array( $collaborators ) ) {
 		return null;
 	}
 
@@ -333,7 +339,7 @@ function create_pressable_site_collaborator( string $collaborator_email, string 
 			break;
 		}
 
-		sleep( $delay );
+		\sleep( $delay );
 	}
 
 	return $collaborator;

--- a/src/helpers/wpcom-api-helper.php
+++ b/src/helpers/wpcom-api-helper.php
@@ -53,7 +53,7 @@ final class WPCOM_API_Helper {
 		);
 
 		if ( 0 !== \strpos( $result['headers']['http_code'], '2' ) ) {
-			$response_body = print_r($result['body'], true);
+			$response_body = print_r( $result['body'], true );
 			console_writeln(
 				"❌ WordPress.com API error ($endpoint): {$result['headers']['http_code']} {$response_body}",
 				\in_array( $result['headers']['http_code'], array( 403, 404 ), true ) ? OutputInterface::VERBOSITY_DEBUG : OutputInterface::VERBOSITY_QUIET


### PR DESCRIPTION
This PR is meant to make it easier to figure out why the tool sometimes fails like in the case of #177. By doing more type checks we eliminate PHP notices (like running `foreach` on a `null`) and we can focus more on the actual error than on corollary ones. 