### PR TITLE
Add stickers command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/helpers/pressable_token.json
 .idea
 sites.csv
 sites.json
+.vscode
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/node,macos,composer,phpstorm+all,visualstudiocode,windows,linux

--- a/load-application.php
+++ b/load-application.php
@@ -2,7 +2,6 @@
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
-use function Team51\Helper\is_quiet_mode;
 
 define( 'TEAM51_CLI_ROOT_DIR', __DIR__ );
 if ( getenv( 'TEAM51_CONTRACTOR' ) ) { // Add the contractor flag automatically if set through the environment.
@@ -15,37 +14,44 @@ require __DIR__ . '/src/helpers/config-loader.php';
 
 $application = new Application();
 
-$application->add( new Team51\Command\Create_Production_Site() );
-$application->add( new Team51\Command\Create_Development_Site() );
-$application->add( new Team51\Command\Create_Repository() );
-$application->add( new Team51\Command\Add_Branch_Protection_Rules() );
-$application->add( new Team51\Command\Delete_Branch_Protection_Rules() );
-$application->add( new Team51\Command\Jetpack_Enable_SSO() );
-$application->add( new Team51\Command\Remove_User() );
-$application->add( new Team51\Command\Update_Repository_Secret() );
-$application->add( new Team51\Command\Plugin_List() );
-$application->add( new Team51\Command\Plugin_Search() );
-$application->add( new Team51\Command\Pressable_Call_Api() );
-$application->add( new Team51\Command\Pressable_Generate_OAuth_Token() );
-$application->add( new Team51\Command\Pressable_Site_Add_Domain() );
-$application->add( new Team51\Command\Pressable_Site_Create_Collaborator() );
-$application->add( new Team51\Command\Pressable_Site_Open_Shell() );
-$application->add( new Team51\Command\Pressable_Site_PHP_Errors() );
-$application->add( new Team51\Command\Pressable_Site_Rotate_Passwords() );
-$application->add( new Team51\Command\Pressable_Site_Rotate_SFTP_User_Password() );
-$application->add( new Team51\Command\Pressable_Site_Rotate_WP_User_Password() );
-$application->add( new Team51\Command\Pressable_Site_Run_WP_CLI_Command() );
-$application->add( new Team51\Command\Pressable_Site_Upload_Icon() );
-$application->add( new Team51\Command\Jetpack_Modules() );
-$application->add( new Team51\Command\Jetpack_Module() );
-$application->add( new Team51\Command\Jetpack_Sites_With() );
-$application->add( new Team51\Command\Triage_GraphQL() );
-$application->add( new Team51\Command\Dump_Commands() );
-$application->add( new Team51\Command\Site_List() );
-$application->add( new Team51\Command\Plugin_Summary() );
-$application->add( new Team51\Command\Get_Site_Stats() );
-$application->add( new Team51\Command\Get_WooCommerce_Stats() );
-$application->add( new Team51\Command\DeployHQ_Rotate_Private_Key() );
+$application->addCommands(
+	array(
+		new Team51\Command\Create_Production_Site(),
+		new Team51\Command\Create_Development_Site(),
+		new Team51\Command\Create_Repository(),
+		new Team51\Command\Add_Branch_Protection_Rules(),
+		new Team51\Command\Delete_Branch_Protection_Rules(),
+		new Team51\Command\Jetpack_Enable_SSO(),
+		new Team51\Command\Remove_User(),
+		new Team51\Command\Update_Repository_Secret(),
+		new Team51\Command\Plugin_List(),
+		new Team51\Command\Plugin_Search(),
+		new Team51\Command\Pressable_Call_Api(),
+		new Team51\Command\Pressable_Generate_OAuth_Token(),
+		new Team51\Command\Pressable_Site_Add_Domain(),
+		new Team51\Command\Pressable_Site_Create_Collaborator(),
+		new Team51\Command\Pressable_Site_Open_Shell(),
+		new Team51\Command\Pressable_Site_PHP_Errors(),
+		new Team51\Command\Pressable_Site_Rotate_Passwords(),
+		new Team51\Command\Pressable_Site_Rotate_SFTP_User_Password(),
+		new Team51\Command\Pressable_Site_Rotate_WP_User_Password(),
+		new Team51\Command\Pressable_Site_Run_WP_CLI_Command(),
+		new Team51\Command\Pressable_Site_Upload_Icon(),
+		new Team51\Command\Jetpack_Modules(),
+		new Team51\Command\Jetpack_Module(),
+		new Team51\Command\Jetpack_Sites_With(),
+		new Team51\Command\Triage_GraphQL(),
+		new Team51\Command\Dump_Commands(),
+		new Team51\Command\Site_List(),
+		new Team51\Command\Plugin_Summary(),
+		new Team51\Command\Get_Site_Stats(),
+		new Team51\Command\Get_WooCommerce_Stats(),
+		new Team51\Command\DeployHQ_Rotate_Private_Key(),
+		new Team51\Command\WPCOM_Get_Stickers(),
+		new Team51\Command\WPCOM_Add_Sticker(),
+		new Team51\Command\WPCOM_Remove_Sticker(),
+	)
+);
 
 foreach ( $application->all() as $command ) {
 	$command->addOption( '--contractor', '-c', InputOption::VALUE_NONE, 'Use the contractor config file.' );

--- a/secrets/config.tpl.json
+++ b/secrets/config.tpl.json
@@ -30,6 +30,9 @@
     "webhook_url": "op://Shared/Team 51 CLI config/Slack/Webhook URL"
   },
   "wpcom": {
-    "api_account_token": "op://Shared/Team 51 CLI config/WordPress.com/API account token"
+    "api_account_token": "op://Shared/Team 51 CLI config/WordPress.com/API account token",
+    "get_stickers_url": "op://Shared/Team 51 CLI config/WordPress.com/Get stickers URL",
+    "add_sticker_url": "op://Shared/Team 51 CLI config/WordPress.com/Add sticker URL",
+    "remove_sticker_url": "op://Shared/Team 51 CLI config/WordPress.com/Remove sticker URL"
   }
 }

--- a/src/commands/wpcom-add-sticker.php
+++ b/src/commands/wpcom-add-sticker.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Team51\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Team51\Helper\WPCOM_API_Helper;
+
+use function Team51\Helper\maybe_define_console_verbosity;
+use function Team51\Helper\get_wpcom_site_from_input;
+use function Team51\Helper\get_string_input;
+
+final class WPCOM_Add_Sticker extends Command {
+	/**
+	 * {@inheritdoc}
+	 */
+	protected static $defaultName = 'wpcom:add-sticker';
+
+
+	/**
+	 * The sticker to add.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $sticker = null;
+
+	/**
+	 * The site object.
+	 *
+	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/
+	 *
+	 * @var object|null
+	 */
+	protected ?object $wpcom_site = null;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Add the specified sticker to the site.' )
+			->setHelp( 'This command allows you add a blog sticker to a site given a site ID or URL.' )
+			->addArgument( 'site', InputArgument::REQUIRED, 'ID or URL of the site to add a sticker.' )
+			->addArgument( 'sticker', InputArgument::REQUIRED, 'Sticker to add to the site.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		maybe_define_console_verbosity( $output->getVerbosity() );
+
+		$this->wpcom_site = get_wpcom_site_from_input( $input, $output, fn() => $this->prompt_site_input( $input, $output ) );
+
+		if ( \is_null( $this->wpcom_site ) ) {
+			exit( 1 ); // Exit if the site does not exist.
+		}
+
+		// Store the ID of the site in the argument field.
+		$input->setArgument( 'site', $this->wpcom_site->ID );
+
+		$this->sticker = get_string_input( $input, $output, 'sticker', fn() => $this->prompt_sticker_input( $input, $output ) );
+
+		if ( empty( $this->sticker ) ) {
+			$output->writeln( '<error>Sticker not provided.</error>' );
+			exit( 1 );
+		}
+
+		$input->setArgument( 'sticker', $this->sticker );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$response = WPCOM_API_Helper::call_api(
+			sprintf( WPCOM_ADD_STICKER_URL, $this->wpcom_site->ID, $this->sticker ),
+			'POST'
+		);
+
+		if ( is_object( $response ) && $response->success ) {
+			$output->writeln( "<info>Successfully added `{$this->sticker}` on site `{$this->wpcom_site->ID}`<info>" );
+		} else {
+			$output->writeln( "<comment>Couldn't add `{$this->sticker}` on site `{$this->wpcom_site->ID}`<comment>" );
+		}
+	}
+
+	/**
+	 * Prompts the user for a site if in interactive mode.
+	 *
+	 * @param InputInterface  $input  The input object.
+	 * @param OutputInterface $output The output object.
+	 *
+	 * @return string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		if ( $input->isInteractive() ) {
+			$question = new Question( '<question>Enter the site ID or URL to add a sticker:</question> ' );
+			$site     = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return $site ?? null;
+	}
+
+	/**
+	 * Prompts the user for a sticker if in interactive mode.
+	 *
+	 * @param InputInterface  $input  The input object.
+	 * @param OutputInterface $output The output object.
+	 *
+	 * @return string|null
+	 */
+	private function prompt_sticker_input( InputInterface $input, OutputInterface $output ): ?string {
+		if ( $input->isInteractive() ) {
+			$question = new Question( '<question>Enter the sticker to add to the site:</question> ' );
+			$sticker  = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return $sticker ?? null;
+	}
+}

--- a/src/commands/wpcom-get-stickers.php
+++ b/src/commands/wpcom-get-stickers.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Team51\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Team51\Helper\WPCOM_API_Helper;
+
+use function Team51\Helper\maybe_define_console_verbosity;
+use function Team51\Helper\get_wpcom_site_from_input;
+
+final class WPCOM_Get_Stickers extends Command {
+	/**
+	 * {@inheritdoc}
+	 */
+	protected static $defaultName = 'wpcom:get-stickers';
+
+	/**
+	 * The site object.
+	 *
+	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/
+	 *
+	 * @var object|null
+	 */
+	protected ?object $wpcom_site = null;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Get a list of a site\'s stickers.' )
+			->setHelp( 'This command allows you get a list of stickers associated with a site given a site ID or URL.' )
+			->addArgument( 'site', InputArgument::REQUIRED, 'ID or URL of the site for which get stickers associated.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		maybe_define_console_verbosity( $output->getVerbosity() );
+
+		$this->wpcom_site = get_wpcom_site_from_input( $input, $output, fn() => $this->prompt_site_input( $input, $output ) );
+
+		if ( \is_null( $this->wpcom_site ) ) {
+			exit( 1 ); // Exit if the site does not exist.
+		}
+
+		// Store the ID of the site in the argument field.
+		$input->setArgument( 'site', $this->wpcom_site->ID );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$stickers = WPCOM_API_Helper::call_api(
+			sprintf( WPCOM_GET_STICKERS_URL, $this->wpcom_site->ID )
+		);
+
+		if ( empty( $stickers ) ) {
+			$output->writeln( '<comment>Site has no stickers associated.<comment>' );
+			exit;
+		}
+
+		$sticker_table = new Table( $output );
+		$sticker_table->setStyle( 'box-double' )
+			->setHeaderTitle( 'Stickers' )
+			->setHeaders( array( "ID: {$this->wpcom_site->ID} ({$this->wpcom_site->URL})" ) )
+			->setRows( array_map( fn ( $sticker ) => array( $sticker ), $stickers ) )
+			->render();
+	}
+
+	/**
+	 * Prompts the user for a site if in interactive mode.
+	 *
+	 * @param InputInterface  $input  The input object.
+	 * @param OutputInterface $output The output object.
+	 *
+	 * @return string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		if ( $input->isInteractive() ) {
+			$question = new Question( '<question>Enter the site ID or URL to query for stickers:</question> ' );
+			$site     = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return $site ?? null;
+	}
+}

--- a/src/commands/wpcom-remove-sticker.php
+++ b/src/commands/wpcom-remove-sticker.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Team51\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Team51\Helper\WPCOM_API_Helper;
+
+use function Team51\Helper\maybe_define_console_verbosity;
+use function Team51\Helper\get_wpcom_site_from_input;
+use function Team51\Helper\get_string_input;
+
+final class WPCOM_Remove_Sticker extends Command {
+	/**
+	 * {@inheritdoc}
+	 */
+	protected static $defaultName = 'wpcom:remove-sticker';
+
+
+	/**
+	 * The sticker to remove.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $sticker = null;
+
+	/**
+	 * The site object.
+	 *
+	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/
+	 *
+	 * @var object|null
+	 */
+	protected ?object $wpcom_site = null;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Remove the specified sticker on the site.' )
+			->setHelp( 'This command allows you remove a sticker to a site given a site ID or URL.' )
+			->addArgument( 'site', InputArgument::REQUIRED, 'ID or URL of the site to remove a sticker.' )
+			->addArgument( 'sticker', InputArgument::REQUIRED, 'Sticker to remove.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		maybe_define_console_verbosity( $output->getVerbosity() );
+
+		$this->wpcom_site = get_wpcom_site_from_input( $input, $output, fn() => $this->prompt_site_input( $input, $output ) );
+
+		if ( \is_null( $this->wpcom_site ) ) {
+			exit( 1 ); // Exit if the site does not exist.
+		}
+
+		// Store the ID of the site in the argument field.
+		$input->setArgument( 'site', $this->wpcom_site->ID );
+
+		$this->sticker = get_string_input( $input, $output, 'sticker', fn() => $this->prompt_sticker_input( $input, $output ) );
+
+		if ( empty( $this->sticker ) ) {
+			$output->writeln( '<error>Sticker not provided.</error>' );
+			exit( 1 );
+		}
+
+		$input->setArgument( 'sticker', $this->sticker );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$response = WPCOM_API_Helper::call_api(
+			sprintf( WPCOM_REMOVE_STICKER_URL, $this->wpcom_site->ID, $this->sticker ),
+			'POST'
+		);
+
+		if ( is_object( $response ) && $response->success ) {
+			$output->writeln( "<info>Successfully removed `{$this->sticker}` on site `{$this->wpcom_site->ID}`<info>" );
+		} else {
+			$output->writeln( "<comment>Couldn't remove `{$this->sticker}` on site `{$this->wpcom_site->ID}`<comment>" );
+		}
+	}
+
+	/**
+	 * Prompts the user for a site if in interactive mode.
+	 *
+	 * @param InputInterface  $input  The input object.
+	 * @param OutputInterface $output The output object.
+	 *
+	 * @return string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		if ( $input->isInteractive() ) {
+			$question = new Question( '<question>Enter the site ID or URL:</question> ' );
+			$site     = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return $site ?? null;
+	}
+
+	/**
+	 * Prompts the user for a sticker if in interactive mode.
+	 *
+	 * @param InputInterface  $input  The input object.
+	 * @param OutputInterface $output The output object.
+	 *
+	 * @return string|null
+	 */
+	private function prompt_sticker_input( InputInterface $input, OutputInterface $output ): ?string {
+		if ( $input->isInteractive() ) {
+			$question = new Question( '<question>Enter the sticker to remove:</question> ' );
+			$sticker  = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return $sticker ?? null;
+	}
+}

--- a/src/helpers/wpcom-api-helper.php
+++ b/src/helpers/wpcom-api-helper.php
@@ -37,9 +37,9 @@ final class WPCOM_API_Helper {
 	 *
 	 * @link    https://developer.wordpress.com/docs/api/
 	 *
-	 * @return  object|null
+	 * @return  object|array|null
 	 */
-	public static function call_api( string $endpoint, string $method = 'GET', array $params = array() ): ?object {
+	public static function call_api( string $endpoint, string $method = 'GET', array $params = array() ) {
 		$result = get_remote_content(
 			self::get_request_url( $endpoint ),
 			array(

--- a/src/helpers/wpcom-functions.php
+++ b/src/helpers/wpcom-functions.php
@@ -2,6 +2,9 @@
 
 namespace Team51\Helper;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
 /**
  * Get the complete list of WordPress.com sites for the a8cteam51 account, including WPORG sites with an active Jetpack
  * connection and including P2 blogs (or any other site the user is merely subscribed to).
@@ -121,4 +124,27 @@ function set_wpcom_site_user_wp_password( string $site_id_or_url, string $user_i
 	}
 
 	return true;
+}
+
+/**
+ * Grabs a value from the console input and tries to retrieve a WPCOM site based on it.
+ *
+ * @param InputInterface  $input         The console input.
+ * @param OutputInterface $output        The console output.
+ * @param callable|null   $no_input_func The function to call if no input is given.
+ * @param string          $name          The name of the value to grab.
+ *
+ * @return object|null
+ */
+function get_wpcom_site_from_input( InputInterface $input, OutputInterface $output, ?callable $no_input_func = null, string $name = 'site' ): ?object {
+	$site_id_or_url = get_site_input( $input, $output, $no_input_func, $name );
+	$wpcom_site     = get_wpcom_site( $site_id_or_url );
+
+	if ( \is_null( $wpcom_site ) ) {
+		$output->writeln( "<error>WPCOM site $site_id_or_url not found.</error>" );
+	} else {
+		$output->writeln( "<comment>WPCOM site found: $wpcom_site->name (ID $wpcom_site->ID, URL $wpcom_site->URL).</comment>", OutputInterface::VERBOSITY_VERY_VERBOSE );
+	}
+
+	return $wpcom_site;
 }


### PR DESCRIPTION
Added three new commands:

- `wpcom:get-stickers`.
- `wpcom:add-sticker <site> <sticker>`.
- `wpcom:remove-sticker <site> <sticker>`.

Also added an `.editorconfig` to the repo to standardize indents, etc.